### PR TITLE
Feeding to CERN AMQ

### DIFF
--- a/spider_cms.py
+++ b/spider_cms.py
@@ -7,6 +7,7 @@ import time
 import random
 import socket
 import classad
+import logging
 import htcondor
 import datetime
 import tempfile
@@ -14,16 +15,20 @@ import traceback
 import collections
 import multiprocessing
 
+from argparse import ArgumentParser
+from logging.handlers import RotatingFileHandler
 
 TIMEOUT_MINS = 11
 
 try:
     import htcondor_es.es
-    import htconodor_es.convert_to_json
+    import htcondor_es.amq
+    import htcondor_es.convert_to_json
 except ImportError:
     if os.path.exists("src/htcondor_es/__init__.py") and "src" not in sys.path:
         sys.path.append("src")
         import htcondor_es.es
+        import htcondor_es.amq
         import htcondor_es.convert_to_json
     else:
         raise
@@ -31,17 +36,20 @@ except ImportError:
 now = time.time()
 now_ns = int(time.time())*int(1e9)
 
-def get_schedds():
+def get_schedds(args):
     schedd_query = classad.ExprTree('!isUndefined(CMSGWMS_Type)')
-    coll = htcondor.Collector("cmssrv221.fnal.gov:9620")
-    schedd_ads = coll.query(htcondor.AdTypes.Schedd, schedd_query, projection=["MyAddress", "ScheddIpAddr", "Name"])
+    coll = htcondor.Collector(args.collector_hostname)
+    schedd_ads = coll.query(htcondor.AdTypes.Schedd,
+                            schedd_query,
+                            projection=["MyAddress", "ScheddIpAddr", "Name"])
     random.shuffle(schedd_ads)
+
     return schedd_ads
 
 
 def clean_old_jobs(starttime, name, es):
     collection_date = htcondor_es.convert_to_json.get_data_collection_time()
-    idx = htcondor_es.es.get_index(time.time())
+    idx = htcondor_es.es.get_index(time.time(), update_es=True)
     body = {"query": {
       "bool": {
         "must" : [
@@ -198,15 +206,21 @@ def report_global_jobs_influx(global_jobs_running, global_jobs_coresrunning, glo
         influx.sendto(text, ('127.0.0.1', 8089))
 
 
-def process_collector():
-    print "Querying collector for data"
+def process_collector(args):
+    logging.debug("Querying collector for data")
+    if args.dry_run: return
     try:
-        coll = htcondor.Collector("cmssrv221.fnal.gov")
-        ads = coll.query(htcondor.AdTypes.Startd, 'DynamicSlot=!=true', ['TotalSlotCpus', 'SlotType', 'Cpus', 'Memory', 'State', 'GLIDEIN_ToRetire', 'GLIDEIN_CMSSite', 'GLIDEIN_Site', 'GLIDEIN_Entry_Name', 'GLIDEIN_Factory'])
+        coll = htcondor.Collector(args.collector_hostname)
+        ads = coll.query(htcondor.AdTypes.Startd,
+                         'DynamicSlot=!=true',
+                         ['TotalSlotCpus', 'SlotType', 'Cpus', 'Memory',
+                          'State', 'GLIDEIN_ToRetire', 'GLIDEIN_CMSSite',
+                          'GLIDEIN_Site', 'GLIDEIN_Entry_Name', 'GLIDEIN_Factory'])
     except RuntimeError, e:
-        print "Failed to query collector:", str(e)
+        logging.debug("Failed to query collector: %s" % str(e))
         return
     info = {}
+
     for ad in ads:
         slots = int(ad.get('TotalSlotCpus', ad.get('Cpus', 1)))
         if ad.get('SlotType', 'Unknown') == 'Partitionable':
@@ -222,8 +236,10 @@ def process_collector():
         else:
             tier = site_info[0]
             country = site_info[1]
-        key = "tier=%s,country=%s,cms_site=%s,site=%s,slot_type=%s,cpus=%d,payloads=%d,memory=%d,entry_point=%s,factory=%s" % \
-           (tier,
+
+        key = ("tier=%s,country=%s,cms_site=%s,site=%s,slot_type=%s,"
+               "cpus=%d,payloads=%d,memory=%d,entry_point=%s,factory=%s") % (
+            tier,
             country,
             ad.get('GLIDEIN_CMSSite', 'Unknown'),
             ad.get('GLIDEIN_Site', 'Unknown'),
@@ -234,6 +250,7 @@ def process_collector():
             ad.get('GLIDEIN_Entry_Name', 'Unknown'),
             ad.get('GLIDEIN_Factory', 'Unknown'),
            )
+
         values = info.setdefault(key, collections.defaultdict(float))
         values['count'] += 1
         if ad.get('SlotType', 'Unknown') == 'Partitionable':
@@ -248,45 +265,54 @@ def process_collector():
             values['retiring_cores'] += ad.get('Cpus', 1)
         else:
             values['unclaimed_cores'] += ad.get('Cpus', 1)
-    text = ''
-    count = 0
-    influx = get_influx_socket()
-    for key, values in info.items():
-        value_info = ",".join(["%s=%s" % (i[0], i[1]) for i in values.items()])
-        text += 'slots,%s %s %d\n' % (key, value_info, now_ns)
-        count += 1
-        if count == 10:
+
+    if args.feed_influxdb:
+        text = ''
+        count = 0
+        influx = get_influx_socket()
+        for key, values in info.items():
+            value_info = ",".join(["%s=%s" % (i[0], i[1]) for i in values.items()])
+            text += 'slots,%s %s %d\n' % (key, value_info, now_ns)
+            count += 1
+            if count == 10:
+                influx.sendto(text, ('127.0.0.1', 8089))
+                count = 0
+                text = ''
+        if text:
             influx.sendto(text, ('127.0.0.1', 8089))
-            count = 0
-            text = ''
-    if text:
-        influx.sendto(text, ('127.0.0.1', 8089))
 
 
-def process_schedd_queue(starttime, schedd_ad):
+def process_schedd_queue(starttime, schedd_ad, args):
     my_start = time.time()
-    print "Querying %s for jobs." % schedd_ad["Name"]
-    buffered_ads = {}
-    schedd = htcondor.Schedd(schedd_ad)
+    logging.debug("Querying %s for jobs." % schedd_ad["Name"])
     if time.time() - starttime > TIMEOUT_MINS*60:
-        print "Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS
+        logging.error("Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS)
         return
     count = 0
     total_upload = 0
 
-    sites_jobs_running = collections.defaultdict(int)
-    sites_jobs_idle    = collections.defaultdict(int)
-    sites_jobs_coresrunning = collections.defaultdict(int)
-    sites_jobs_coresidle    = collections.defaultdict(int)
-    global_jobs_running = collections.defaultdict(int)
+    sites_jobs_running       = collections.defaultdict(int)
+    sites_jobs_idle          = collections.defaultdict(int)
+    sites_jobs_coresrunning  = collections.defaultdict(int)
+    sites_jobs_coresidle     = collections.defaultdict(int)
+    global_jobs_running      = collections.defaultdict(int)
     global_jobs_coresrunning = collections.defaultdict(int)
-    global_jobs_idle = collections.defaultdict(int)
-    global_jobs_coresidle = collections.defaultdict(int)
+    global_jobs_idle         = collections.defaultdict(int)
+    global_jobs_coresidle    = collections.defaultdict(int)
 
+    schedd = htcondor.Schedd(schedd_ad)
+    buffered_ads = {}
     had_error = True
     try:
-        es = htcondor_es.es.get_server_handle()
-        query_iter = schedd.xquery()
+        if not args.read_only:
+            if args.feed_es:
+                es = htcondor_es.es.get_server_handle(args)
+            if args.feed_amq:
+                amq = htcondor_es.amq.get_amq_interface()
+        if not args.dry_run:
+            query_iter = schedd.xquery()
+        else:
+            query_iter = []
         json_ad = '{}'
         for job_ad in query_iter:
             json_ad, dict_ad = htcondor_es.convert_to_json.convert_to_json(job_ad, return_dict=True)
@@ -307,102 +333,146 @@ def process_schedd_queue(starttime, schedd_ad):
                 elif job_ad['JobStatus'] == 1:
                     global_jobs_idle[global_key] += 1
                     global_jobs_coresidle[global_key] += job_ad.get('RequestCpus', 1)
-            idx = htcondor_es.es.get_index(job_ad["QDate"])
+            idx = htcondor_es.es.get_index(job_ad["QDate"], update_es=(args.feed_es and not args.read_only))
             ad_list = buffered_ads.setdefault(idx, [])
-            ad_list.append((job_ad["GlobalJobId"], json_ad))
+            ad_list.append((job_ad["GlobalJobId"], json_ad, dict_ad))
             if len(ad_list) == 250:
                 st = time.time()
-                htcondor_es.es.post_ads(es, idx, ad_list)
+                if not args.read_only:
+                    if args.feed_es:
+                        htcondor_es.es.post_ads(es.handle, idx, [(id_, json_ad) for id_, json_ad, _ in ad_list])
+                    if args.feed_amq:
+                        htcondor_es.amq.post_ads(amq, [(id_, dict_ad) for id_, _, dict_ad in ad_list])
+                logging.debug("...posting %d ads from %s (process_schedd_queue)" % (len(ad_list), schedd_ad["Name"]))
                 total_upload += time.time() - st
                 buffered_ads[idx] = []
             count += 1
             if time.time() - starttime > TIMEOUT_MINS*60:
-                print "Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS
+                logging.error("Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS)
                 break
         had_error=False
     except RuntimeError:
-        print "Failed to query schedd for jobs:", schedd_ad["Name"]
+        logging.error("Failed to query schedd for jobs: %s" % schedd_ad["Name"])
     except Exception, e:
-        print "Failure when processing schedd query:", str(e)
+        logging.error("Failure when processing schedd query: %s" % str(e))
         traceback.print_exc()
 
     for idx, ad_list in buffered_ads.items():
         if ad_list:
-            htcondor_es.es.post_ads(es, idx, ad_list)
+            logging.debug("...posting remaining %d ads from %s (process_schedd_queue)" % (len(ad_list), schedd_ad["Name"]))
+            if not args.read_only:
+                if args.feed_es:
+                    htcondor_es.es.post_ads(es.handle, idx, [(id_, json_ad) for id_, json_ad, _ in ad_list])
+                if args.feed_amq:
+                    htcondor_es.amq.post_ads(amq,    [(id_, dict_ad) for id_, _, dict_ad in ad_list])
+
     buffered_ads.clear()
 
     total_time = (time.time() - my_start)/60.
     total_upload = total_upload / 60.
-    print "Schedd %s total response count: %d; total query time %.2f min; total upload time %.2f min" % (schedd_ad["Name"], count, total_time-total_upload, total_upload)
-    clean_old_jobs(starttime, schedd_ad["Name"], es)
+    logging.warning(("Schedd %s queue: response count: %d; "
+                     "query time %.2f min; "
+                     "upload time %.2f min") % (
+                           schedd_ad["Name"], count,
+                           total_time-total_upload, total_upload))
+    # clean_old_jobs(starttime, schedd_ad["Name"], es) # FIXME
 
     try:
-        if not had_error:
+        if not had_error and args.feed_influxdb:
             report_site_jobs_influx(sites_jobs_running, sites_jobs_coresrunning, sites_jobs_idle, sites_jobs_coresidle)
             report_global_jobs_influx(global_jobs_running, global_jobs_coresrunning, global_jobs_idle, global_jobs_coresidle)
     except Exception, e:
-        print "Failure when uploading InfluxDB results:", str(e)
+        logging.error("Failure when uploading InfluxDB results: %s" % str(e))
         traceback.print_exc()
 
 
-def process_schedd(starttime, last_completion, schedd_ad):
-    buffered_ads = {}
+def process_schedd(starttime, last_completion, schedd_ad, args):
     my_start = time.time()
+    if time.time() - starttime > TIMEOUT_MINS*60:
+        logging.error("Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS)
+        return last_completion
+
     schedd = htcondor.Schedd(schedd_ad)
     history_query = classad.ExprTree("EnteredCurrentStatus >= %d" % last_completion)
-    if time.time() - starttime > TIMEOUT_MINS*60:
-        print "Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS
-        return last_completion
-    print "Querying %s for history: %s.  %.1f minutes of ads" % (schedd_ad["Name"], history_query, (time.time()-last_completion)/60.)
+    logging.info("Querying %s for history: %s.  %.1f minutes of ads" % (schedd_ad["Name"],
+                                                                 history_query,
+                                                                 (time.time()-last_completion)/60.))
+    buffered_ads = {}
     count = 0
     total_upload = 0
-    es = htcondor_es.es.get_server_handle()
+    if not args.read_only:
+        if args.feed_es:
+            es = htcondor_es.es.get_server_handle(args) # es-cms5.cern.ch now
+        if args.feed_amq:
+            amq = htcondor_es.amq.get_amq_interface()
     try:
-        history_iter = schedd.history(history_query, [], 10000)
+        if not args.dry_run:
+            history_iter = schedd.history(history_query, [], 10000)
+        else:
+            history_iter = []
         json_ad = '{}'
+
         for job_ad in history_iter:
-            json_ad = htcondor_es.convert_to_json.convert_to_json(job_ad)
+            json_ad, dict_ad = htcondor_es.convert_to_json.convert_to_json(job_ad, return_dict=True)
             if not json_ad:
                 continue
-            idx = htcondor_es.es.get_index(job_ad["QDate"])
+
+            idx = htcondor_es.es.get_index(job_ad["QDate"], update_es=(args.feed_es and not args.read_only))
             ad_list = buffered_ads.setdefault(idx, [])
-            ad_list.append((job_ad["GlobalJobId"], json_ad))
+            ad_list.append((job_ad["GlobalJobId"], json_ad, dict_ad))
+
             if len(ad_list) == 250:
                 st = time.time()
-                htcondor_es.es.post_ads(es, idx, ad_list)
+                if not args.read_only:
+                    if args.feed_es:
+                        htcondor_es.es.post_ads(es.handle, idx, [(id_, json_ad) for id_, json_ad, _ in ad_list])
+                    if args.feed_amq:
+                        htcondor_es.amq.post_ads(amq, [(id_, dict_ad) for id_, _, dict_ad in ad_list])
+                logging.debug("...posting %d ads from %s (process_schedd)" % (len(ad_list), schedd_ad["Name"]))
                 total_upload += time.time() - st
                 buffered_ads[idx] = []
+
             count += 1
             job_completion = job_ad.get("EnteredCurrentStatus")
             if job_completion > last_completion:
                 last_completion = job_completion
             if time.time() - starttime > TIMEOUT_MINS*60:
-                print "Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS
+                logging.error("Crawler has been running for more than %d minutes; exiting." % TIMEOUT_MINS)
                 break
-    except RuntimeError:
-        print "Failed to query schedd for history:", schedd_ad["Name"]
-    except Exception, e:
-        print "Failure when processing schedd:", str(e)
 
+    except RuntimeError:
+        logging.error("Failed to query schedd for history: %s" % schedd_ad["Name"])
+    except Exception, e:
+        logging.error("Failure when processing schedd: %s" % str(e))
+
+    # Post the remaining ads
     for idx, ad_list in buffered_ads.items():
         if ad_list:
-            htcondor_es.es.post_ads(es, idx, ad_list)
+            logging.debug("...posting remaining %d ads from %s (process_schedd)" % (len(ad_list), schedd_ad["Name"]))
+            if not args.read_only:
+                if args.feed_es:
+                    htcondor_es.es.post_ads(es.handle, idx, [(id_, json_ad) for id_, json_ad, _ in ad_list])
+                if args.feed_amq:
+                    htcondor_es.amq.post_ads(amq, [(id_, dict_ad) for id_, _, dict_ad in ad_list])
+
 
     total_time = (time.time() - my_start) / 60.
     total_upload /= 60.
-    print "Schedd %s total response count: %d; last completion %s; total query time %.2f min; total upload time %.2f min" % \
-        (schedd_ad["Name"],
-         count,
-         datetime.datetime.fromtimestamp(last_completion).strftime("%Y-%m-%d %H:%M:%S"),
-         total_time - total_upload,
-         total_upload)
+    logging.warning(("Schedd %s history: response count: %d; last completion %s; "
+                     "query time %.2f min; upload time %.2f min") % (
+                      schedd_ad["Name"],
+                      count,
+                      datetime.datetime.fromtimestamp(last_completion).strftime("%Y-%m-%d %H:%M:%S"),
+                      total_time - total_upload,
+                      total_upload))
 
     try:
         checkpoint_new = json.load(open("checkpoint.json"))
     except:
         checkpoint_new = {}
 
-    if (schedd_ad["Name"] not in checkpoint_new) or (checkpoint_new[schedd_ad["Name"]] < last_completion):
+    if ( (schedd_ad["Name"] not in checkpoint_new) or 
+         (checkpoint_new[schedd_ad["Name"]] < last_completion) ):
         checkpoint_new[schedd_ad["Name"]] = last_completion
 
     fd, tmpname = tempfile.mkstemp(dir=".", prefix="checkpoint.json.new")
@@ -414,11 +484,31 @@ def process_schedd(starttime, last_completion, schedd_ad):
     # Now that we have the fresh history, process the queues themselves.
     domain = socket.getfqdn().split(".", 1)[-1]
     if domain != 'cern.ch':
-        process_schedd_queue(starttime, schedd_ad)
+        process_schedd_queue(starttime, schedd_ad, args)
     return last_completion
 
 
-def main():
+def set_up_logging(args):
+    """Configure root logger with rotating file handler"""
+    logger = logging.getLogger()
+
+    log_level = getattr(logging, args.log_level.upper(), None)
+    if not isinstance(log_level, int):
+        raise ValueError('Invalid log level: %s' % log_level)
+    logger.setLevel(log_level)
+
+    if not os.path.isdir(args.log_dir):
+        os.system('mkdir -p %s' % args.log_dir)
+
+    log_file = os.path.join(args.log_dir, 'spider_cms.log')
+    filehandler = RotatingFileHandler(log_file, maxBytes=100000)
+    filehandler.setFormatter(
+        logging.Formatter('%(asctime)s : %(name)s:%(levelname)s - %(message)s'))
+
+    logger.addHandler(filehandler)
+
+
+def main(args):
 
     try:
         checkpoint = json.load(open("checkpoint.json"))
@@ -427,24 +517,29 @@ def main():
 
     starttime = time.time()
 
+    # Get all the schedd ads
     pool = multiprocessing.Pool(processes=10)
-    future = pool.apply_async(get_schedds)
+    future = pool.apply_async(get_schedds, (args,))
     schedd_ads = future.get(TIMEOUT_MINS*60)
-    print "There are %d schedds to query." % len(schedd_ads)
+    logging.warning("There are %d schedds to query." % len(schedd_ads))
 
     futures = []
-    future = pool.apply_async(process_collector)
+    future = pool.apply_async(process_collector, (args,))
     futures.append(('collector', future))
 
     for schedd_ad in schedd_ads:
         name = schedd_ad["Name"]
-        #if name != "vocms0309.cern.ch": continue
-        last_completion = checkpoint.get(name, 0)
+        # if name != "vocms0313.cern.ch": continue ## DEBUG
+        last_completion = checkpoint.get(name, time.time()-12*3600) # only get 12h by default
+        # last_completion = checkpoint.get(name, 0) # get everything by default
         if name.startswith("crab") and last_completion == 0:
             last_completion = time.time()-12*3600
-        future = pool.apply_async(process_schedd, (starttime, last_completion, schedd_ad))
+
+        future = pool.apply_async(process_schedd, (starttime, last_completion, schedd_ad, args))
+        
+        # process_schedd(starttime, last_completion, schedd_ad, args) ## DEBUG
         futures.append((name, future))
-        #break
+        # break ## DEBUG
 
     pool.close()
 
@@ -455,9 +550,10 @@ def main():
             try:
                 last_completion = future.get(time_remaining)
                 if name:
-                    checkpoint[schedd_ad["name"]] = last_completion
+                    checkpoint[name] = last_completion
+                    # checkpoint[schedd_ad["name"]] = last_completion
             except multiprocessing.TimeoutError:
-                print "Schedd %s timed out; ignoring progress." % name
+                logging.warning("Schedd %s timed out; ignoring progress." % name)
         else:
             timed_out = True
             break
@@ -481,9 +577,44 @@ def main():
     fd.close()
     os.rename(tmpname, "checkpoint.json")
 
-    print "Total processing time: %.2f mins" % ((time.time()-starttime)/60.)
+    logging.warning("Total processing time: %.2f mins" % ((time.time()-starttime)/60.))
 
 
 if __name__ == "__main__":
-    main()
+    parser = ArgumentParser()
+    parser.add_argument("--feed_influxdb", action='store_true',
+                        dest="feed_influxdb",
+                        help="Feed also to InfluxDB")
+    parser.add_argument("--feed_es", action='store_true',
+                        dest="feed_es",
+                        help="Feed to Elasticsearch")
+    parser.add_argument("--feed_amq", action='store_true',
+                        dest="feed_amq",
+                        help="Feed to CERN AMQ")
+    parser.add_argument("--read_only", action='store_true',
+                        dest="read_only",
+                        help="Only read the info, don't submit it.")
+    parser.add_argument("--dry_run", action='store_true',
+                        dest="dry_run",
+                        help=("Don't even read info, just pretend to. (Still "
+                              "query the collector for the schedd's though.)"))
+    parser.add_argument("--collector_hostname", default='cmssrv221.fnal.gov',
+                        type=str, dest="collector_hostname",
+                        help="Hostname of the condor collector to be queried [default: %(default)s]")
+    parser.add_argument("--es_hostname", default='es-cms5.cern.ch',
+                        type=str, dest="es_hostname",
+                        help="Hostname of the elasticsearch instance to be used [default: %(default)s]")
+    parser.add_argument("--es_port", default=9203,
+                        type=int, dest="es_port",
+                        help="Port of the elasticsearch instance to be used [default: %(default)d]")
+    parser.add_argument("--log_dir", default='log/',
+                        type=str, dest="log_dir",
+                        help="Directory for logging information [default: %(default)s]")
+    parser.add_argument("--log_level", default='WARNING',
+                        type=str, dest="log_level",
+                        help="Log level (CRITICAL/ERROR/WARNING/INFO/DEBUG) [default: %(default)s]")
+    args = parser.parse_args()
+    set_up_logging(args)
+
+    main(args)
 

--- a/src/htcondor_es/StompAMQ.py
+++ b/src/htcondor_es/StompAMQ.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+"""
+Basic interface to CERN ActiveMQ via stomp
+"""
+from __future__ import print_function
+from __future__ import division
+
+import json
+import logging
+import time
+import uuid
+
+import stomp
+
+class StompyListener(object):
+    """
+    Auxiliar listener class to fetch all possible states in the Stomp
+    connection.
+    """
+    def __init__(self):
+        self.logr = logging.getLogger(__name__)
+
+    def on_connecting(self, host_and_port):
+        self.logr.info('on_connecting %s', str(host_and_port))
+
+    def on_error(self, headers, message):
+        self.logr.info('received an error %s %s', str(headers), str(message))
+
+    def on_message(self, headers, body):
+        self.logr.info('on_message %s %s', str(headers), str(body))
+
+    def on_heartbeat(self):
+        self.logr.info('on_heartbeat')
+
+    def on_send(self, frame):
+        self.logr.info('on_send HEADERS: %s, BODY: %s ...', str(frame.headers), str(frame.body)[:160])
+
+    def on_connected(self, headers, body):
+        self.logr.info('on_connected %s %s', str(headers), str(body))
+
+    def on_disconnected(self):
+        self.logr.info('on_disconnected')
+
+    def on_heartbeat_timeout(self):
+        self.logr.info('on_heartbeat_timeout')
+
+    def on_before_message(self, headers, body):
+        self.logr.info('on_before_message %s %s', str(headers), str(body))
+
+        return (headers, body)
+
+
+class StompAMQ(object):
+    """
+    Class to generate and send notifications to a given Stomp broker
+    and a given topic.
+
+    :param username: The username to connect to the broker.
+    :param password: The password to connect to the broker.
+    :param producer: The 'producer' field in the notification header
+    :param topic: The topic to be used on the broker
+    :param host_and_ports: The hosts and ports list of the brokers.
+        E.g.: [('agileinf-mb.cern.ch', 61213)]
+    """
+
+    # Version number to be added in header
+    _version = '0.1'
+
+    def __init__(self, username, password,
+                 producer='CMS_WMCore_StompAMQ',
+                 topic='/topic/cms.jobmon.wmagent',
+                 host_and_ports=None):
+        self._host_and_ports = host_and_ports or [('agileinf-mb.cern.ch', 61213)]
+        self._username = username
+        self._password = password
+        self._producer = producer
+        self._topic = topic
+
+        self._logger = logging.getLogger(__name__)
+
+    def send(self, data):
+        """
+        Connect to the stomp host and send a single notification
+        (or a list of notifications).
+
+        :param data: Either a single notification (as returned by
+            `make_notification`) or a list of such.
+
+        :return: a list of successfully sent notification bodies
+        """
+
+        conn = stomp.Connection(host_and_ports=self._host_and_ports)
+        conn.set_listener('StompyListener', StompyListener())
+        try:
+            conn.start()
+            conn.connect(username=self._username, passcode=self._password, wait=True)
+        except stomp.exception.ConnectFailedException as exc:
+            self._logger.error("Connection to %s failed %s", repr(self._host_and_ports), str(exc))
+            return []
+        except stomp.exception.ConnectFailedException as exc:
+            self._logger.error("Not connected: %s %s", repr(self._host_and_ports), str(exc))
+            return []
+
+        # If only a single notification, put it in a list
+        if isinstance(data, dict) and 'topic' in data:
+            data = [data]
+
+        successfully_sent = []
+        for notification in data:
+            body = self._send_single(conn, notification)
+            if body:
+                successfully_sent.append(body)
+
+        if conn.is_connected():
+            conn.disconnect()
+
+        self._logger.warning('Sent %d docs to %s', len(successfully_sent), repr(self._host_and_ports))
+        return successfully_sent
+
+    def _send_single(self, conn, notification):
+        """
+        Send a single notification to `conn`
+
+        :param conn: An already connected stomp.Connection
+        :param notification: A dictionary as returned by `make_notification`
+
+        :return: The notification body in case of success, or else None
+        """
+        try:
+            body = notification.pop('body')
+            destination = notification.pop('topic')
+            conn.send(destination=destination,
+                      headers=notification,
+                      body=json.dumps(body),
+                      ack='auto')
+            self._logger.debug('Notification %s sent', str(notification))
+            return body
+        except Exception as exc:
+            self._logger.error('Notification: %s not send, error: %s',
+                          str(notification), str(exc))
+            return None
+
+
+    def make_notification(self, payload, id_, producer=None,
+                          type_='cms_wmagent_info'):
+        """
+        Generate a notification with the specified data
+
+        :param payload: Actual notification data.
+        :param id_: Id representing the notification.
+        :param producer: The notification producer.
+            Default: StompAMQ._producer
+
+        :return: the generated notification
+        """
+        producer = producer or self._producer
+
+        notification = {}
+        notification['topic'] = self._topic
+
+        # Add headers
+        headers = {
+                   'type': type_,
+                   'version': self._version,
+                   'producer': producer
+        }
+
+        notification.update(headers)
+
+        # Add body consisting of the payload and metadata
+        body = {
+            # 'payload': payload,
+            'metadata': {
+                'timestamp': int(time.time()),
+                'id': id_,
+                'uuid': str(uuid.uuid1()),
+            }
+        }
+        body.update(payload)
+
+        notification['body'] = body
+
+        return notification
+    

--- a/src/htcondor_es/amq.py
+++ b/src/htcondor_es/amq.py
@@ -1,0 +1,35 @@
+from htcondor_es.StompAMQ import StompAMQ
+StompAMQ._version = '0.1.2'
+
+_amq_interface = None
+def get_amq_interface():
+    global _amq_interface
+    if not _amq_interface:
+        try:
+            username = open('username', 'r').read().strip()
+            password = open('password', 'r').read().strip()
+        except IOError:
+            print "ERROR: Provide username/password for CERN AMQ"
+            return []
+        _amq_interface = StompAMQ(username=username,
+                                    password=password,
+                                    topic='/topic/cms.jobmon.condor',
+                                    host_and_ports=[('dashb-mb.cern.ch', 61113)])
+
+    return _amq_interface
+
+
+def post_ads(interface, ads):
+    if not len(ads):
+        logging.warning("No new documents found")
+        return
+
+    list_data = []
+    for id_, ad in ads:
+        list_data.append(interface.make_notification(payload=ad,
+                                                     id_=id_,
+                                                     type_='htcondor_job_info'))
+
+    sent_data = interface.send(list_data)
+    return sent_data
+


### PR DESCRIPTION
- Add options for dry-running and read-only
- Add options for enabling/disabling feed to ES and AMQ
- Add option to specify hostname and port for ES
- Date and time data format changed to milliseconds (was seconds)
- Use logging module instead of print statements