### PR TITLE
[Untested] Dynamic template for strings to be of type keyword

### DIFF
--- a/spider_cms.py
+++ b/spider_cms.py
@@ -341,7 +341,9 @@ def process_schedd_queue(starttime, schedd_ad, args):
                 elif job_ad['JobStatus'] == 1:
                     global_jobs_idle[global_key] += 1
                     global_jobs_coresidle[global_key] += job_ad.get('RequestCpus', 1)
-            idx = htcondor_es.es.get_index(job_ad["QDate"], update_es=(args.feed_es and not args.read_only))
+            idx = htcondor_es.es.get_index(job_ad["QDate"],
+                                           template=args.es_index_template,
+                                           update_es=(args.feed_es and not args.read_only))
             ad_list = buffered_ads.setdefault(idx, [])
             ad_list.append((job_ad["GlobalJobId"], json_ad, dict_ad))
             if len(ad_list) == 250:
@@ -425,7 +427,9 @@ def process_schedd(starttime, last_completion, schedd_ad, args):
             if not json_ad:
                 continue
 
-            idx = htcondor_es.es.get_index(job_ad["QDate"], update_es=(args.feed_es and not args.read_only))
+            idx = htcondor_es.es.get_index(job_ad["QDate"],
+                                           template=args.es_index_template,
+                                           update_es=(args.feed_es and not args.read_only))
             ad_list = buffered_ads.setdefault(idx, [])
             ad_list.append((job_ad["GlobalJobId"], json_ad, dict_ad))
 
@@ -614,6 +618,9 @@ if __name__ == "__main__":
     parser.add_argument("--es_port", default=9203,
                         type=int, dest="es_port",
                         help="Port of the elasticsearch instance to be used [default: %(default)d]")
+    parser.add_argument("--es_index_template", default='cms',
+                        type=str, dest="es_index_template",
+                        help="Trunk of index pattern [default: %(default)s]")
     parser.add_argument("--log_dir", default='log/',
                         type=str, dest="log_dir",
                         help="Directory for logging information [default: %(default)s]")

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -391,7 +391,6 @@ no_analysis = set([
   "REQUIRED_OS",
   "ShouldTransferFiles",
   "WhenToTransferOutput",
-  "InputData",
   "DAGParentNodeNames",
 ])
 

--- a/src/htcondor_es/es.py
+++ b/src/htcondor_es/es.py
@@ -23,27 +23,46 @@ def filter_name(keys):
 
 
 def make_mappings():
-    mappings = {}
+    props = {}
     for name in filter_name(htcondor_es.convert_to_json.int_vals):
-        mappings[name] = {"type": "long"}
+        props[name] = {"type": "long"}
     for name in filter_name(htcondor_es.convert_to_json.string_vals):
         if name in htcondor_es.convert_to_json.no_idx:
-            mappings[name] = {"type": "text", "index": "no"}
+            props[name] = {"type": "text", "index": "no"}
         elif name in htcondor_es.convert_to_json.no_analysis:
-            mappings[name] = {"type": "text", "index": "not_analyzed"}
-        else:
-            mappings[name] = {"type": "keyword"} #, "analyzer": "analyzer_keyword"}
+            props[name] = {"type": "text", "index": "not_analyzed"}
+        # else:
+        #     props[name] = {"type": "keyword"} #, "analyzer": "analyzer_keyword"}
     for name in filter_name(htcondor_es.convert_to_json.date_vals):
-        mappings[name] = {"type": "date", "format": "epoch_millis"}
+        props[name] = {"type": "date", "format": "epoch_millis"}
     for name in filter_name(htcondor_es.convert_to_json.bool_vals):
-        mappings[name] = {"type": "boolean"}
-    mappings["Args"]["index"] = "no"
-    mappings["Cmd"]["index"] = "no"
-    mappings["StartdPrincipal"]["index"] = "no"
-    mappings["StartdIpAddr"]["index"] = "no"
-    # mappings["x509UserProxyFQAN"]["analyzer"] = "standard"
-    # mappings["x509userproxysubject"]["analyzer"] = "standard"
+        props[name] = {"type": "boolean"}
+    props["Args"]["index"] = "no"
+    props["Cmd"]["index"] = "no"
+    props["StartdPrincipal"]["index"] = "no"
+    props["StartdIpAddr"]["index"] = "no"
+    # props["x509UserProxyFQAN"]["analyzer"] = "standard"
+    # props["x509userproxysubject"]["analyzer"] = "standard"
 
+    dynamic_string_template = {
+        "strings_as_keywords" : {
+            "match_mapping_type" : "string",
+            "mapping" : {
+                "type" : "keyword",
+                "norms" : "false",
+                "ignore_above" : 256
+            }
+        }
+    }
+
+    mappings = {
+        "job": {
+            "dynamic_templates": [
+                dynamic_string_template
+            ],
+            "properties": props
+        }
+    }
     return mappings
 
 
@@ -95,9 +114,9 @@ class ElasticInterface(object):
     def fix_mapping(self, idx, template="cms"):
         idx_clt = elasticsearch.client.IndicesClient(self.handle)
         mappings = make_mappings()
-        custom_mappings = {"CMSPrimaryDataTier": mappings["CMSPrimaryDataTier"],
-                           "CMSPrimaryPrimaryDataset": mappings["CMSPrimaryPrimaryDataset"],
-                           "CMSPrimaryProcessedDataset": mappings["CMSPrimaryProcessedDataset"]}
+        custom_mappings = {"CMSPrimaryDataTier": mappings["job"]["properties"]["CMSPrimaryDataTier"],
+                           "CMSPrimaryPrimaryDataset": mappings["job"]["properties"]["CMSPrimaryPrimaryDataset"],
+                           "CMSPrimaryProcessedDataset": mappings["job"]["properties"]["CMSPrimaryProcessedDataset"]}
         logging.info(idx_clt.put_mapping(doc_type="job", index=idx, body=json.dumps({"properties": custom_mappings}), ignore=400))
 
     def make_mapping(self, idx, template="cms"):
@@ -106,7 +125,8 @@ class ElasticInterface(object):
         #print idx_clt.put_mapping(doc_type="job", index=idx, body=json.dumps({"properties": mappings}), ignore=400)
         settings = make_settings()
         #print idx_clt.put_settings(index=idx, body=json.dumps(settings), ignore=400)
-        body = json.dumps({"mappings": {"job": {"properties": mappings} },
+
+        body = json.dumps({"mappings": mappings,
                            "settings": {"index": settings},
                           })
 


### PR DESCRIPTION
Added a dynamic template in mappings such that any string field will be mapped as a 'keyword':

```python
"dynamic_templates" : [{
    "strings_as_keywords" : {
        "match_mapping_type" : "string",
        "mapping" : {
            "type" : "keyword",
            "norms" : "false",
            "ignore_above" : 256
        }
    }
}]
```

Fields listed in `no_idx` and `no_analysis` (see https://github.com/bbockelm/cms-htcondor-es/blob/master/src/htcondor_es/convert_to_json.py#L357 and https://github.com/bbockelm/cms-htcondor-es/blob/master/src/htcondor_es/convert_to_json.py#L382) have their own mapping as `text`.

Haven't tested this, so don't merge yet.

See also documentation [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-templates.html).