### PR TITLE
Inconsistent data type for MachineAttrMJF_JOB_HS06_JOB0

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -763,6 +763,8 @@ def convert_to_json(ad, cms=True, return_dict=False):
             result['HS06CoreHr'] = result['CoreHr'] * result['BenchmarkJobHS06']
             result["HS06CommittedCoreHr"] = result['CommittedCoreHr'] * result['BenchmarkJobHS06']
             result['HS06CpuTimeHr'] = result['CpuTimeHr'] * result['BenchmarkJobHS06']
+        except ValueError:
+            result.pop('MachineAttrMJF_JOB_HS06_JOB0', None)
         except:
             pass
     if ('MachineAttrDIRACBenchmark0' in ad) and classad.ExprTree('MachineAttrDIRACBenchmark0 isnt undefined').eval(ad):


### PR DESCRIPTION
We could just drop the field when it's Unknown. Currently we try to use it to calculate and when that fails we leave it as it is, leading to the different types.