### PR TITLE
Avoid processing the same schedd several times

### DIFF
--- a/spider_cms.py
+++ b/spider_cms.py
@@ -42,14 +42,19 @@ def get_schedds():
                   "cmsgwms-collector-tier0.cern.ch:9620",
                   "cmssrv276.fnal.gov"]
 
-    schedd_ads = []
+    schedd_ads = {}
     for host in collectors:
         coll = htcondor.Collector(host)
-        schedd_ads += coll.query(htcondor.AdTypes.Schedd,
-                                 schedd_query,
-                                 projection=["MyAddress", "ScheddIpAddr", "Name"])
+        schedds = coll.query(htcondor.AdTypes.Schedd,
+                            schedd_query,
+                            projection=["MyAddress", "ScheddIpAddr", "Name"])
 
-    schedd_ads = [ad for ad in schedd_ads if 'Name' in ad]
+        for schedd in schedds:
+            try:
+                schedd_ads[schedd['Name']] = schedd
+            except KeyError: pass
+
+    schedd_ads = schedd_ads.values()
     random.shuffle(schedd_ads)
 
     return schedd_ads


### PR DESCRIPTION
I noticed that we have a good fraction of duplicates in our list of schedds, since we query several collectors. This avoids adding schedds whose names are already in the list.

Running this on bbockelm-es I found 91 schedds, of which 32 were duplicates, i.e. 59 uniques.