### PR TITLE
Improved performance for queue processing

### DIFF
--- a/spider_cms.py
+++ b/spider_cms.py
@@ -520,9 +520,6 @@ def process_schedd(starttime, last_completion, schedd_ad, args):
     fd.close()
     os.rename(tmpname, "checkpoint.json")
 
-    # Now that we have the fresh history, process the queues themselves.
-    if args.process_queue:
-        process_schedd_queue(starttime, schedd_ad, args)
     return last_completion
 
 
@@ -587,8 +584,6 @@ def main(args):
 
         futures.append((name, future))
 
-    pool.close()
-
     # Check whether one of the processes timed out and reset their last
     # completion checkpoint in case
     timed_out = False
@@ -608,7 +603,6 @@ def main(args):
             break
     if timed_out:
         pool.terminate()
-    pool.join()
 
 
     # Update the last completion checkpoint file
@@ -627,8 +621,43 @@ def main(args):
     fd.close()
     os.rename(tmpname, "checkpoint.json")
 
-    logging.warning("Total processing time: %.2f mins" % (
+    logging.warning("Total processing time for history: %.2f mins" % (
                     (time.time()-starttime)/60.))
+
+
+    # Now that we have the fresh history, process the queues themselves.
+    if not args.process_queue:
+        return 0
+
+    futures = []
+    for schedd_ad in schedd_ads:
+        future = pool.apply_async(process_schedd_queue,
+                                     (starttime, schedd_ad, args) )
+        futures.append((schedd_ad['Name'], future))
+
+    pool.close()
+
+    timed_out = False
+    for name, future in futures:
+        time_remaining = TIMEOUT_MINS*60+10 - (time.time() - starttime)
+        if time_remaining > 0:
+            try:
+                future.get(time_remaining)
+            except multiprocessing.TimeoutError:
+                logging.warning("Schedd %s timed out; ignoring progress." %
+                                 name)
+        else:
+            timed_out = True
+            break
+    if timed_out:
+        pool.terminate()
+
+    pool.join()
+
+    logging.warning("Total processing time for history and queue: %.2f mins"
+                      % ((time.time()-starttime)/60.))
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/spider_cms.py
+++ b/spider_cms.py
@@ -332,7 +332,9 @@ def process_schedd_queue(starttime, schedd_ad, args):
             query_iter = []
         json_ad = '{}'
         for job_ad in query_iter:
-            json_ad, dict_ad = convert_to_json(job_ad, return_dict=True)
+            json_ad, dict_ad = convert_to_json(job_ad,
+                                    return_dict=True,
+                                    reduce_data=args.reduce_running_data)
             if not json_ad:
                 continue
 
@@ -681,6 +683,9 @@ if __name__ == "__main__":
                         dest="dry_run",
                         help=("Don't even read info, just pretend to. (Still "
                               "query the collector for the schedd's though.)"))
+    parser.add_argument("--reduce_running_data", action='store_true',
+                        dest="reduce_running_data",
+                        help="Drop all but some fields for running jobs.")
     parser.add_argument("--bunching", default=250,
                         type=int, dest="bunching",
                         help=("Send docs in bunches of this number "

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -408,6 +408,57 @@ bool_vals = set([
   "CMSSWDone",
 ])
 
+# Fields to be kept in docs concerning running jobs
+running_fields = set([
+  "BenchmarkJobDB12",
+  "Campaign",
+  "CMS_JobType",
+  "CMSGroups",
+  "CMSPrimaryDataTier",
+  "CMSSWKLumis",
+  "CMSSWWallHrs",
+  "CommittedCoreHr",
+  "CoreHr",
+  "Country",
+  "CpuBadput",
+  "CpuEff",
+  "CpuEventRate",
+  "CpuTimeHr",
+  "CpuTimePerEvent",
+  "CRAB_AsyncDest",
+  "CRAB_DataBlock",
+  "CRAB_UserHN",
+  "CRAB_Workflow",
+  # "DataLocations",
+  "DESIRED_CMSDataset",
+  # "DESIRED_Sites",
+  "EventRate",
+  "GlobalJobId",
+  "HasSingularity",
+  "InputData",
+  "InputGB",
+  "KEvents",
+  "MegaEvents",
+  "MemoryMB",
+  "OutputGB",
+  "QueueHrs",
+  "ReadTimeMins",
+  "RecordTime",
+  "RequestCpus",
+  "RequestMemory",
+  "ScheddName",
+  "Site",
+  "Status",
+  "TaskType",
+  "Tier",
+  "TimePerEvent",
+  "Type",
+  "WallClockHr",
+  "WMAgent_RequestName",
+  "WMAgent_SubTaskName",
+  "Workflow",
+])
+
 status = { \
   0: "Unexpanded",
   1: "Idle",
@@ -448,7 +499,7 @@ _rereco_re = re.compile("[A-Za-z0-9_]+_Run20[A-Za-z0-9-_]+-([A-Za-z0-9]+)")
 _split_re = re.compile("\s*,?\s*")
 _generic_site = re.compile("^[A-Za-z0-9]+_[A-Za-z0-9]+_(.*)_")
 _cms_site = re.compile("CMS[A-Za-z]*_(.*)_")
-def convert_to_json(ad, cms=True, return_dict=False):
+def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
     analysis = ("CRAB_Id" in ad) or (ad.get("AccountingGroup", "").startswith("analysis."))
     if ad.get("TaskType") == "ROOT":
         if return_dict:
@@ -791,6 +842,9 @@ def convert_to_json(ad, cms=True, return_dict=False):
         result['CPUModelName'] = str(ad['MachineAttrCPUModel0'])
         result['Processor'] = str(ad['MachineAttrCPUModel0'])
 
+    if reduce_data:
+        result = drop_fields_for_running_jobs(result)
+
     if return_dict:
         return json.dumps(result), result
     else:
@@ -804,3 +858,12 @@ def convert_dates_to_millisecs(record):
         except (KeyError, TypeError): continue
 
     return record
+
+def drop_fields_for_running_jobs(record):
+    skimmed_record = {}
+    for field in running_fields:
+        try:
+            skimmed_record[field] = record[field]
+        except KeyError: continue
+
+    return skimmed_record


### PR DESCRIPTION
Two changes:

1. Finish processing the full history first before starting the queue, such that completed jobs get preferential treatment (and hopefully never time out within the 11 min window). Hence incomplete data due to timeouts should only concern running/pending jobs.

2. Drop all but a few relevant fields from the documents for running/pending jobs to speed up the upload time. These documents only have transient relevance in some graphs on the dashboard (and are superseded by the documents for completed jobs), hence we don't really need the full content for them. This speeds up the upload time sufficiently to generally stay within the 11 min window.