### PR TITLE
Asynchronous querying and sending of docs

### DIFF
--- a/src/htcondor_es/StompAMQ.py
+++ b/src/htcondor_es/StompAMQ.py
@@ -114,7 +114,7 @@ class StompAMQ(object):
         if conn.is_connected():
             conn.disconnect()
 
-        self._logger.warning('Sent %d docs to %s', len(successfully_sent), repr(self._host_and_ports))
+        self._logger.info('Sent %d docs to %s', len(successfully_sent), repr(self._host_and_ports))
         return successfully_sent
 
     def _send_single(self, conn, notification):

--- a/src/htcondor_es/amq.py
+++ b/src/htcondor_es/amq.py
@@ -1,3 +1,6 @@
+import time
+import logging
+import multiprocessing
 from htcondor_es.StompAMQ import StompAMQ
 StompAMQ._version = '0.1.2'
 
@@ -19,11 +22,12 @@ def get_amq_interface():
     return _amq_interface
 
 
-def post_ads(interface, ads):
+def post_ads(ads):
     if not len(ads):
         logging.warning("No new documents found")
         return
 
+    interface = get_amq_interface()
     list_data = []
     for id_, ad in ads:
         list_data.append(interface.make_notification(payload=ad,
@@ -31,5 +35,4 @@ def post_ads(interface, ads):
                                                      type_='htcondor_job_info'))
 
     sent_data = interface.send(list_data)
-    return sent_data
-
+    return (len(sent_data), len(ads))

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -502,10 +502,7 @@ _cms_site = re.compile("CMS[A-Za-z]*_(.*)_")
 def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
     analysis = ("CRAB_Id" in ad) or (ad.get("AccountingGroup", "").startswith("analysis."))
     if ad.get("TaskType") == "ROOT":
-        if return_dict:
-            return None, None
-        else:
-            return None
+        return None
     result = {}
     result['DataCollection'] = ad.get("CompletionDate", 0)
     result['RecordTime'] = ad.get("CompletionDate", 0)
@@ -846,10 +843,9 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
         result = drop_fields_for_running_jobs(result)
 
     if return_dict:
-        return json.dumps(result), result
+        return result
     else:
         return json.dumps(result)
-
 
 def convert_dates_to_millisecs(record):
     for date_field in date_vals:

--- a/src/htcondor_es/es.py
+++ b/src/htcondor_es/es.py
@@ -164,3 +164,14 @@ def post_ads(es, idx, ads):
     es.bulk(body=body, doc_type="job", index=idx)
 
 
+def post_ads_nohandle(idx, ads, args):
+    es = get_server_handle(args).handle
+    body = ''
+    for id, ad in ads:
+        body += json.dumps({"index": {"_id": id}}) + "\n"
+        body += ad + "\n"
+    es.bulk(body=body, doc_type="job", index=idx)
+    ## FIXME: Check if successful?
+
+    return len(ads)
+


### PR DESCRIPTION
- Start sending docs in parallel while schedd queue queries are still running
- convert_to_json now either returns json (default, as before) or dict, not both
- Factorized processing of history and queue into functions to clean up main
- History processing is untouched w.r.t. before
- Tested for both ES and AMQ