### PR TITLE
Set metadata.timestamp to RecordTime for docs sent to amq

### DIFF
--- a/src/htcondor_es/StompAMQ.py
+++ b/src/htcondor_es/StompAMQ.py
@@ -142,7 +142,8 @@ class StompAMQ(object):
 
 
     def make_notification(self, payload, id_, producer=None,
-                          type_='cms_wmagent_info'):
+                          type_='cms_wmagent_info',
+                          timestamp=None):
         """
         Generate a notification with the specified data
 
@@ -168,10 +169,11 @@ class StompAMQ(object):
         notification.update(headers)
 
         # Add body consisting of the payload and metadata
+        timestamp = timestamp or time.time()
         body = {
             # 'payload': payload,
             'metadata': {
-                'timestamp': int(time.time()),
+                'timestamp': int(timestamp),
                 'id': id_,
                 'uuid': str(uuid.uuid1()),
             }

--- a/src/htcondor_es/amq.py
+++ b/src/htcondor_es/amq.py
@@ -32,7 +32,8 @@ def post_ads(ads):
     for id_, ad in ads:
         list_data.append(interface.make_notification(payload=ad,
                                                      id_=id_,
-                                                     type_='htcondor_job_info'))
+                                                     type_='htcondor_job_info',
+                                                     timestamp=ad['RecordTime']))
 
     sent_data = interface.send(list_data)
     return (len(sent_data), len(ads))


### PR DESCRIPTION
Something that came with the discussion about the old documents. Apparently MONIT relies on the metadata.timestamp to distribute documents into a date-based directory structure on hdfs. This is probably not very relevant for live-fed data, but might avoid some issues.

The commit just sets the metadata timestamp to the RecordTime.