### PR TITLE
Delay terminating the listener until query processes finish

### DIFF
--- a/spider_cms.py
+++ b/spider_cms.py
@@ -768,7 +768,7 @@ def process_queues(schedd_ads, starttime, pool, args):
         if args.read_only:
             break
 
-        if time_remaining(starttime) < 0:
+        if time_remaining(starttime) < -10:
             logging.warning("Listener did not shut down properly; terminating.")
             listener.terminate()
             break


### PR DESCRIPTION
Add a 10s delay before killing the listener, so the `process_schedd_queue`'s have time to stop sending and terminating