### PR TITLE
Set RecordTime to launch time for unfinished jobs

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -532,13 +532,15 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
     if ad.get("TaskType") == "ROOT":
         return None
     result = {}
-    result['DataCollection'] = ad.get("CompletionDate", 0)
-    result['RecordTime'] = ad.get("CompletionDate", 0)
-    if not result['DataCollection']:
-        result['DataCollection'] = _launch_time
-    if not result['RecordTime']:
-        result['RecordTime'] = _launch_time
+
+    result['DataCollection'] = ad.get('CompletionDate', _launch_time)
+    result['RecordTime'] = _launch_time
+    # Keep RecordTime as _launch_time for unfinished jobs
+    if ad['JobStatus'] in [3, 4, 6] and 'CompletionDate' in ad:
+        result['RecordTime'] = ad['CompletionDate']
+
     result['DataCollectionDate'] = result['RecordTime']
+
     result['ScheddName'] = ad.get("GlobalJobId", "UNKNOWN").split("#")[0]
     if cms and analysis:
         result["Type"] = "analysis"


### PR DESCRIPTION
This is for #40 

Set the `RecordTime` to be the launch time for jobs in statuses 0, 1, 2, 5 ("Unexpanded", "Idle", "Running", and "Held"). In other words, set `RecordTime` to be `DataCollection` only for 3, 4, and 6 ("Removed", "Completed", and "Error").

@bbockelm Does this split look good to you?