### PR TITLE
Setting a unique metadata id for each document

### DIFF
--- a/src/htcondor_es/StompAMQ.py
+++ b/src/htcondor_es/StompAMQ.py
@@ -174,9 +174,10 @@ class StompAMQ(object):
             # 'payload': payload,
             'metadata': {
                 'timestamp': int(timestamp),
-                'id': id_,
+                '_id': id_,
                 'uuid': str(uuid.uuid1()),
-            }
+            },
+            '_id': id_
         }
         body.update(payload)
 

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -924,3 +924,14 @@ def drop_fields_for_running_jobs(record):
         except KeyError: continue
 
     return skimmed_record
+
+
+def unique_doc_id(doc):
+    """
+    Return a string of format "<GlobalJobId>#<RecordTime>"
+    To uniquely identify documents (not jobs)
+
+    Note that this uniqueness breaks if the same jobs are submitted
+    with the same RecordTime
+    """
+    return "%s#%d" % (doc['GlobalJobId'], doc['RecordTime'])

--- a/src/htcondor_es/history.py
+++ b/src/htcondor_es/history.py
@@ -18,6 +18,7 @@ import htcondor_es.amq
 from htcondor_es.utils import send_email_alert, time_remaining, TIMEOUT_MINS
 from htcondor_es.convert_to_json import convert_to_json
 from htcondor_es.convert_to_json import convert_dates_to_millisecs
+from htcondor_es.convert_to_json import unique_doc_id
 
 
 def process_schedd(starttime, last_completion, schedd_ad, args):
@@ -74,7 +75,7 @@ def process_schedd(starttime, last_completion, schedd_ad, args):
                                            template=args.es_index_template,
                                            update_es=(args.feed_es and not args.read_only))
             ad_list = buffered_ads.setdefault(idx, [])
-            ad_list.append((job_ad["GlobalJobId"], dict_ad))
+            ad_list.append((unique_doc_id(dict_ad), dict_ad))
 
             if len(ad_list) == args.bunching:
                 st = time.time()

--- a/src/htcondor_es/queues.py
+++ b/src/htcondor_es/queues.py
@@ -16,6 +16,7 @@ import htcondor_es.amq
 from htcondor_es.utils import send_email_alert, time_remaining, TIMEOUT_MINS
 from htcondor_es.convert_to_json import convert_to_json
 from htcondor_es.convert_to_json import convert_dates_to_millisecs
+from htcondor_es.convert_to_json import unique_doc_id
 
 
 
@@ -140,7 +141,7 @@ def process_schedd_queue(starttime, schedd_ad, queue, args):
             if not dict_ad:
                 continue
 
-            batch.append((job_ad["GlobalJobId"], dict_ad))
+            batch.append((unique_doc_id(dict_ad), dict_ad))
             count += 1
             count_since_last_report += 1
 


### PR DESCRIPTION
As discussed with MONIT, this is to have a unique identifier per document, set as `<GlobalJobId>#<RecordTime>`. Note that these are only unique per doc as long as there are no two docs for the same job with the same `RecordTime`. (In other words, merge #43 first.)