### PR TITLE
Allow for negative remaining time when waiting for uploaders to finish

### DIFF
--- a/src/htcondor_es/queues.py
+++ b/src/htcondor_es/queues.py
@@ -271,7 +271,7 @@ def process_queues(schedd_ads, starttime, pool, args):
     total_upload_time = 0
     total_queried = 0
     for name, future in futures:
-        if time_remaining(starttime) > -20:
+        if time_remaining(starttime, positive=False) > -20:
             try:
                 count = future.get(time_remaining(starttime)+10)
                 if name == "UPLOADER_AMQ":


### PR DESCRIPTION
Since we changed the default behavior of `time_remaining` to return positive numbers, we need to explicitly allow for negative numbers when comparing to negative numbers.