### PR TITLE
Increased request_timeout for posting to es

### DIFF
--- a/src/htcondor_es/es.py
+++ b/src/htcondor_es/es.py
@@ -161,7 +161,7 @@ def post_ads(es, idx, ads):
     for id, ad in ads:
         body += json.dumps({"index": {"_id": id}}) + "\n"
         body += ad + "\n"
-    es.bulk(body=body, doc_type="job", index=idx)
+    es.bulk(body=body, doc_type="job", index=idx, request_timeout=30)
 
 
 def post_ads_nohandle(idx, ads, args):


### PR DESCRIPTION
I started seeing ES timeout errors when we started feeding es-cms and MONIT simultaneously.
Increasing the `request_timeout` from 10 (default) to 30 (temporarily?) fixes this problem.

Eventually we should move to use `es.helpers.bulk` instead of `es.bulk` and make sure documents get re-sent if the first attempt times out.