### PR TITLE
Fixing RecordTime for jobs with CompletionDate = 0

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -542,7 +542,7 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
     result['DataCollection'] = ad.get('CompletionDate', _launch_time)
     result['RecordTime'] = _launch_time
     # Keep RecordTime as _launch_time for unfinished jobs
-    if ad['JobStatus'] in [3, 4, 6] and 'CompletionDate' in ad:
+    if ad['JobStatus'] in [3, 4, 6] and ad.get('CompletionDate', 0) > 0:
         result['RecordTime'] = ad['CompletionDate']
 
     result['DataCollectionDate'] = result['RecordTime']


### PR DESCRIPTION
I noticed we were missing jobs with Status "Removed". Digging a bit into it, we allowed them to have RecordTime = 0, which messes up their placement in ES and influxdb.