### PR TITLE
Adding a field for AccountingGroupClass

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -558,6 +558,8 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
     elif cms:
         result["Type"] = "production"
 
+    result["AccountingGroupClass"] = ad.get("AccountingGroup", "unknown").split('.', 1)[0]
+
     if cms:
         ad.setdefault("MATCH_EXP_JOB_GLIDEIN_CMSSite", ad.get("MATCH_EXP_JOBGLIDEIN_CMSSite", "Unknown"))
 


### PR DESCRIPTION
Just splitting off the first part of the AccountingGroup string.
Possible values should be "analysis", "production", "highprio", "tier0", and "unknown".

I'm wondering whether we really need this. In Kibana/ES it's possible to use the AccountingGroup field directly for this, so it would only be useful if we need it as a tag in InfluxDB.
