### PR TITLE
Retain AutoClusterId information

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -10,6 +10,7 @@ import datetime
 import htcondor
 
 string_vals = set([ \
+  "AutoClusterId",
   "Processor",
   "ChirpCMSSWCPUModels",
   "CPUModel",
@@ -236,7 +237,6 @@ ignore = set([
   "AcctGroupUser",
   "AllowOpportunistic",
   "AutoClusterAttrs",
-  "AutoClusterId",
   "BufferBlockSize",
   "BufferSize",
   "CondorPlatform",
@@ -418,6 +418,7 @@ bool_vals = set([
 
 # Fields to be kept in docs concerning running jobs
 running_fields = set([
+  "AutoClusterId",
   "BenchmarkJobDB12",
   "Campaign",
   "CMS_JobType",


### PR DESCRIPTION
As discussed in the meeting today (Jan 16)

@bbockelm (if you see this): was there a particular reason for dropping this information?