### PR TITLE
Adding CRAB ID to the running fields

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -440,6 +440,7 @@ running_fields = set([
   "CpuTimePerEvent",
   "CRAB_AsyncDest",
   "CRAB_DataBlock",
+  "CRAB_Id",
   "CRAB_UserHN",
   "CRAB_Workflow",
   "CRAB_SplitAlgo",


### PR DESCRIPTION
In order to use CRAB ID as job identifier in dashboards, all tasks need a CRAB ID. #80