### PR TITLE
Increasing index.mapping.total_fields.limit to 2000 

### DIFF
--- a/src/htcondor_es/es.py
+++ b/src/htcondor_es/es.py
@@ -68,12 +68,15 @@ def make_mappings():
 
 
 def make_settings():
-    settings = {"analysis": {"analyzer": \
-        {"analyzer_keyword": { \
-            "tokenizer": "keyword",
-            "filter": "lowercase",
-        }
-    }}}
+    settings = {"analysis": {
+                    "analyzer": {
+                        "analyzer_keyword": {
+                            "tokenizer": "keyword",
+                            "filter": "lowercase",
+                            }
+                        }
+                    },
+                "mapping.total_fields.limit": 2000}
     return settings
 
 


### PR DESCRIPTION
This should prevent documents being rejected because the maximum number of fields on the index is reached and they introduce new ones. Will be obsolete if we clean up SiteIO fields (see #82).