### PR TITLE
Committed wall clock in seconds

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -611,6 +611,7 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
     result["CoreHr"] = ad.get("RequestCpus", 1.0)*int(ad.get("RemoteWallClockTime", 0))/3600.
     result["CommittedCoreHr"] = ad.get("RequestCpus", 1.0)*ad.get("CommittedTime", 0)/3600.
     result["CommittedWallClockHr"] = ad.get("CommittedTime", 0)/3600.
+    result["CommittedWallClockSc"] = ad.get("CommittedTime", 0)
     result["CpuTimeHr"] = (ad.get("RemoteSysCpu", 0)+ad.get("RemoteUserCpu", 0))/3600.
     result["DiskUsageGB"] = ad.get("DiskUsage_RAW", 0)/1000000.
     result["MemoryMB"] = ad.get("ResidentSetSize_RAW", 0)/1024.


### PR DESCRIPTION
In order to use the value directly in grafana, when it cannot be transformed (e.g. when we query for the raw document), we need the value in seconds. This is required, for example, when we want to use the table component in grafana because it's only possible to transform a value if it is queried as a metric; in this case, that requires several nested groupings, which make the query heavy for ES.