### PR TITLE
Add user affiliation (institute and country) to the published document

### DIFF
--- a/cronAggregation.sh
+++ b/cronAggregation.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export PYTHONPATH="$DIR/src/:$DIR/../CMSMonitoring/src/python:$PYTHONPATH"
+
+create=$(cat <<EOF
+from htcondor_es.AffiliationManager import AffiliationManager, AffiliationManagerException
+try:
+    AffiliationManager(recreate_older_days=1)
+except AffiliationManagerException as e:
+    import traceback
+    traceback.print_exc()
+    print('There was an error creating the affiliation manager')
+EOF
+)
+python -c "$create"

--- a/spider_cms.py
+++ b/spider_cms.py
@@ -22,6 +22,7 @@ import htcondor_es.history
 import htcondor_es.queues
 from htcondor_es.utils import get_schedds, set_up_logging
 from htcondor_es.utils import collect_metadata, TIMEOUT_MINS
+from htcondor_es.AffiliationManager import AffiliationManager
 
 
 signal.alarm(TIMEOUT_MINS*60 + 60)
@@ -40,12 +41,14 @@ def main_driver(args):
     pool = multiprocessing.Pool(processes=args.query_pool_size)
 
     metadata = collect_metadata()
+    aff_mgr = AffiliationManager(recreate_older_days=1)
 
     if not args.skip_history:
         htcondor_es.history.process_histories(schedd_ads=schedd_ads,
                                               starttime=starttime,
                                               pool=pool,
                                               args=args,
+                                              kwargs={'aff_mgr':aff_mgr},
                                               metadata=metadata)
 
     # Now that we have the fresh history, process the queues themselves.
@@ -54,6 +57,7 @@ def main_driver(args):
                                           starttime=starttime,
                                           pool=pool,
                                           args=args,
+                                          kwargs={'aff_mgr':aff_mgr},
                                           metadata=metadata)
 
     pool.close()

--- a/src/htcondor_es/AffiliationManager.py
+++ b/src/htcondor_es/AffiliationManager.py
@@ -61,16 +61,24 @@ class AffiliationManager():
                             break
                     if login:
                         _tmp_dir[login] = {'institute': _json[x]['institute'],
-                                           'country': _json[x]['institute_country']}
+                                           'country': _json[x]['institute_country'],
+                                           'dn': _json[x]['dn']}
                 json.dump(_tmp_dir, _dir_file)
         else:
             with open(self.path, 'rb') as dir_file:
                 _tmp_dir = json.load(dir_file)
         return _tmp_dir
 
-    def getAffiliation(self, login):
+    def getAffiliation(self, login=None, dn=None):
         """
         Returns a python dictionary with the institute and country
-        for the given login
+        for the given login or dn.
+        Returns None if not found.
         """
-        return self.__dir[login]
+        if login:
+            return self.__dir[login]
+        elif dn:
+            for _person in self.__dir.values():
+                if _person['dn'] == dn:
+                    return _person
+        return None

--- a/src/htcondor_es/AffiliationManager.py
+++ b/src/htcondor_es/AffiliationManager.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Christian Ariza <christian.ariza AT gmail [DOT] com>
+# pylint: disable=line-too-long
+import os
+import json
+import requests
+from datetime import datetime, timedelta
+
+
+class AffiliationManager():
+    __DEFAULT_URL = 'https://cms-cric-dev.cern.ch/api/accounts/user/query/?json'
+    __DEFAULT_DIR_PATH = 'dir.pkl'
+
+    def __init__(self,
+                 pickle_file=__DEFAULT_DIR_PATH,
+                 recreate=False,
+                 recreate_older_days=None,
+                 service_url=__DEFAULT_URL):
+        """
+        params:
+            recreate: boolean
+            recreate_older_days: int, recreate the dir if is older
+                    than that number of days.
+        """
+        self.path = pickle_file
+        self.url = service_url
+        if not recreate\
+           and recreate_older_days \
+           and os.path.isfile(self.path):
+            _min_date = datetime.now() - timedelta(days=recreate_older_days)
+            _dir_time = datetime.fromtimestamp(os.path.getmtime(self.path))
+            recreate = _dir_time < _min_date
+        self.__dir = self.loadOrCreateDirectory(recreate)
+
+    def loadOrCreateDirectory(self, recreate=False):
+        """
+        Create or load from a json file an inverted
+        index of instutions by person login. e.g.:
+
+        {
+            'valya':{u'country': u'US',
+                     u'institute': u'Cornell University'},
+            'belforte': {u'country': u'IT',
+                         u'institute': u'Universita e INFN Trieste'}
+            ...
+        }
+        """
+        _tmp_dir = None
+        if not os.path.isfile(self.path) or recreate:
+            with open(self.path, 'wb') as _dir_file:
+                response = requests.get(self.url, verify=False)
+                _json = json.loads(response.text)
+                _tmp_dir = {}
+                for x in _json:
+                    person = _json[x]
+                    login = None
+                    for profile in person['profiles']:
+                        if 'login' in profile:
+                            login = profile['login']
+                            break
+                    if login:
+                        _tmp_dir[login] = {'institute': _json[x]['institute'],
+                                           'country': _json[x]['institute_country']}
+                json.dump(_tmp_dir, _dir_file)
+        else:
+            with open(self.path, 'rb') as dir_file:
+                _tmp_dir = json.load(dir_file)
+        return _tmp_dir
+
+    def getAffiliation(self, login):
+        """
+        Returns a python dictionary with the institute and country
+        for the given login
+        """
+        return self.__dir[login]

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -10,9 +10,12 @@ import datetime
 import zlib
 import base64
 import htcondor
+from htcondor_es.AffiliationManager import AffiliationManager
 
 string_vals = set([ \
   "AutoClusterId",
+  "AffiliationInstitute",
+  "AffiliationCountry",
   "Processor",
   "ChirpCMSSWCPUModels",
   "CPUModel",
@@ -422,6 +425,8 @@ bool_vals = set([
 running_fields = set([
   "AccountingGroup",
   "AutoClusterId",
+  "AffiliationInstitute",
+  "AffiliationCountry",
   "BenchmarkJobDB12",
   "Campaign",
   "CMS_JobType",
@@ -559,11 +564,13 @@ _rereco_re = re.compile("[A-Za-z0-9_]+_Run20[A-Za-z0-9-_]+-([A-Za-z0-9]+)")
 _generic_site = re.compile("^[A-Za-z0-9]+_[A-Za-z0-9]+_(.*)_")
 _cms_site = re.compile("CMS[A-Za-z]*_(.*)_")
 _cmssw_version = re.compile("CMSSW_((\d*)_(\d*)_.*)")
-def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
+
+def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False, aff_mgr=None):
     if ad.get("TaskType") == "ROOT":
         return None
+    if not aff_mgr:
+        aff_mgr = AffiliationManager(recreate=False)
     result = {}
-
     result['RecordTime'] = recordTime(ad)
     result['DataCollection'] = ad.get('CompletionDate', 0) or _launch_time
     result['DataCollectionDate'] = result['RecordTime']
@@ -774,7 +781,17 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
         result['CPUModel'] = str(ad['MachineAttrCPUModel0'])
         result['CPUModelName'] = str(ad['MachineAttrCPUModel0'])
         result['Processor'] = str(ad['MachineAttrCPUModel0'])
-
+   
+   # Affiliation data:
+    _aff = None
+    if 'CRAB_UserHN' in result:
+        _aff = aff_mgr.getAffiliation(login=result['CRAB_UserHN'])
+    elif 'x509userproxysubject' in result:
+        _aff = aff_mgr.getAffiliation(dn=result['x509userproxysubject'])
+    
+    if _aff is not None: 
+        result['AffiliationInstitute'] = _aff['institute']
+        result['AffiliationCountry'] = _aff['country']
     if reduce_data:
         result = drop_fields_for_running_jobs(result)
 

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -568,8 +568,6 @@ _cmssw_version = re.compile("CMSSW_((\d*)_(\d*)_.*)")
 def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False, aff_mgr=None):
     if ad.get("TaskType") == "ROOT":
         return None
-    if not aff_mgr:
-        aff_mgr = AffiliationManager(recreate=False)
     result = {}
     result['RecordTime'] = recordTime(ad)
     result['DataCollection'] = ad.get('CompletionDate', 0) or _launch_time
@@ -783,15 +781,16 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False, aff_mgr=
         result['Processor'] = str(ad['MachineAttrCPUModel0'])
    
    # Affiliation data:
-    _aff = None
-    if 'CRAB_UserHN' in result:
-        _aff = aff_mgr.getAffiliation(login=result['CRAB_UserHN'])
-    elif 'x509userproxysubject' in result:
-        _aff = aff_mgr.getAffiliation(dn=result['x509userproxysubject'])
-    
-    if _aff is not None: 
-        result['AffiliationInstitute'] = _aff['institute']
-        result['AffiliationCountry'] = _aff['country']
+    if aff_mgr:
+        _aff = None
+        if 'CRAB_UserHN' in result:
+            _aff = aff_mgr.getAffiliation(login=result['CRAB_UserHN'])
+        elif 'x509userproxysubject' in result:
+            _aff = aff_mgr.getAffiliation(dn=result['x509userproxysubject'])
+        
+        if _aff is not None: 
+            result['AffiliationInstitute'] = _aff['institute']
+            result['AffiliationCountry'] = _aff['country']
     if reduce_data:
         result = drop_fields_for_running_jobs(result)
 

--- a/src/htcondor_es/history.py
+++ b/src/htcondor_es/history.py
@@ -21,7 +21,7 @@ from htcondor_es.convert_to_json import convert_dates_to_millisecs
 from htcondor_es.convert_to_json import unique_doc_id
 
 
-def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args, metadata=None):
+def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args, metadata=None,kwargs={}):
     """
     Given a schedd, process its entire set of history since last checkpoint.
     """
@@ -59,7 +59,7 @@ def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args
         for job_ad in history_iter:
             dict_ad = None
             try:
-                dict_ad = convert_to_json(job_ad, return_dict=True)
+                dict_ad = convert_to_json(job_ad, return_dict=True,**kwargs)
             except Exception as e:
                 message = ("Failure when converting document on %s history: %s" %
                            (schedd_ad["Name"], str(e)))

--- a/src/htcondor_es/history.py
+++ b/src/htcondor_es/history.py
@@ -21,7 +21,7 @@ from htcondor_es.convert_to_json import convert_dates_to_millisecs
 from htcondor_es.convert_to_json import unique_doc_id
 
 
-def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args, metadata=None,kwargs={}):
+def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args, metadata=None,aff_mgr=None):
     """
     Given a schedd, process its entire set of history since last checkpoint.
     """
@@ -59,7 +59,7 @@ def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args
         for job_ad in history_iter:
             dict_ad = None
             try:
-                dict_ad = convert_to_json(job_ad, return_dict=True,**kwargs)
+                dict_ad = convert_to_json(job_ad, return_dict=True, aff_mgr=aff_mgr)
             except Exception as e:
                 message = ("Failure when converting document on %s history: %s" %
                            (schedd_ad["Name"], str(e)))
@@ -175,7 +175,7 @@ def update_checkpoint(name, completion_date):
         json.dump(checkpoint, fd)
 
 
-def process_histories(schedd_ads, starttime, pool, args, metadata=None):
+def process_histories(schedd_ads, starttime, pool, args, metadata=None, aff_mgr=None):
     """
     Process history files for each schedd listed in a given
     multiprocessing pool
@@ -209,7 +209,8 @@ def process_histories(schedd_ads, starttime, pool, args, metadata=None):
                                    checkpoint_queue,
                                    schedd_ad,
                                    args,
-                                   metadata))
+                                   metadata,
+                                   aff_mgr))
         futures.append((name, future))
 
     def _chkp_updater():

--- a/src/htcondor_es/queues.py
+++ b/src/htcondor_es/queues.py
@@ -107,7 +107,7 @@ class ListenAndBunch(multiprocessing.Process):
         self.output_queue.put(self.count_in, timeout=time_remaining(self.starttime))
 
 
-def query_schedd_queue(starttime, schedd_ad, queue, args):
+def query_schedd_queue(starttime, schedd_ad, queue, args, kwargs={}):
     my_start = time.time()
     logging.info("Querying %s queue for jobs.", schedd_ad["Name"])
     if time_remaining(starttime) < 10:
@@ -133,7 +133,7 @@ def query_schedd_queue(starttime, schedd_ad, queue, args):
             dict_ad = None
             try:
                 dict_ad = convert_to_json(job_ad, return_dict=True,
-                                          reduce_data=not args.keep_full_queue_data)
+                                          reduce_data=not args.keep_full_queue_data, **kwargs)
             except Exception as e:
                 message = ("Failure when converting document on %s queue: %s" %
                            (schedd_ad["Name"], str(e)))

--- a/src/htcondor_es/queues.py
+++ b/src/htcondor_es/queues.py
@@ -107,7 +107,7 @@ class ListenAndBunch(multiprocessing.Process):
         self.output_queue.put(self.count_in, timeout=time_remaining(self.starttime))
 
 
-def query_schedd_queue(starttime, schedd_ad, queue, args, kwargs={}):
+def query_schedd_queue(starttime, schedd_ad, queue, args, aff_mgr=None):
     my_start = time.time()
     logging.info("Querying %s queue for jobs.", schedd_ad["Name"])
     if time_remaining(starttime) < 10:
@@ -133,7 +133,7 @@ def query_schedd_queue(starttime, schedd_ad, queue, args, kwargs={}):
             dict_ad = None
             try:
                 dict_ad = convert_to_json(job_ad, return_dict=True,
-                                          reduce_data=not args.keep_full_queue_data, **kwargs)
+                                          reduce_data=not args.keep_full_queue_data, aff_mgr=aff_mgr)
             except Exception as e:
                 message = ("Failure when converting document on %s queue: %s" %
                            (schedd_ad["Name"], str(e)))

--- a/tests/testDocConversion.py
+++ b/tests/testDocConversion.py
@@ -19,6 +19,7 @@ except ImportError:
 
 from htcondor_es.utils import get_schedds
 from htcondor_es.convert_to_json import convert_to_json
+from htcondor_es.AffiliationManager import AffiliationManager
 
 
 def process_pickle(filename, args):
@@ -26,13 +27,15 @@ def process_pickle(filename, args):
     dumpfile_name = filename.strip('.pck')
     dumpfile = os.path.join(args.dump_target, '%s.json' % dumpfile_name)
     count = 0
+    aff_mgr = AffiliationManager()
+    kwargs = {'aff_mgr': aff_mgr}
     with open(filename, 'r') as pfile, open(dumpfile, 'w') as dfile:
         try:
             job_ads = pickle.load(pfile)
         except Exception, e:
             print e
 
-        dict_ads = [convert_to_json(job_ad, return_dict=True) for job_ad in job_ads]
+        dict_ads = [convert_to_json(job_ad, return_dict=True, **kwargs) for job_ad in job_ads]
         dict_ads = filter(None, dict_ads)
         json.dump(dict_ads, dfile, indent=4, sort_keys=True)
         count = len(dict_ads)

--- a/tests/testDocConversion.py
+++ b/tests/testDocConversion.py
@@ -28,14 +28,13 @@ def process_pickle(filename, args):
     dumpfile = os.path.join(args.dump_target, '%s.json' % dumpfile_name)
     count = 0
     aff_mgr = AffiliationManager()
-    kwargs = {'aff_mgr': aff_mgr}
     with open(filename, 'r') as pfile, open(dumpfile, 'w') as dfile:
         try:
             job_ads = pickle.load(pfile)
         except Exception, e:
             print e
 
-        dict_ads = [convert_to_json(job_ad, return_dict=True, **kwargs) for job_ad in job_ads]
+        dict_ads = [convert_to_json(job_ad, return_dict=True, aff_mgr=aff_mgr) for job_ad in job_ads]
         dict_ads = filter(None, dict_ads)
         json.dump(dict_ads, dfile, indent=4, sort_keys=True)
         count = len(dict_ads)


### PR DESCRIPTION
It uses CRAB_UserHN if present, else it uses  x509userproxysubject if exists, else it doesn't add the attributes. 

I tested it with some documents using testDocConversion.py, however, I have not tested the changes on spider_cms.py. @stiegerb  can you help me to test that? Do we have a testing environment? 

The new fields will be "AffiliationInstitute" and  "AffiliationCountry"