### PR TITLE
query for the jobs that where updated after the last completion

### DIFF
--- a/src/htcondor_es/history.py
+++ b/src/htcondor_es/history.py
@@ -37,7 +37,9 @@ def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args
 
     metadata = metadata or {}
     schedd = htcondor.Schedd(schedd_ad)
-    history_query = classad.ExprTree("EnteredCurrentStatus >= %d" % last_completion)
+    _q = "EnteredCurrentStatus >= %(last_completion)d "\
+            "or CRAB_PostJobLastUpdate >= %(last_completion)d" 
+    history_query = classad.ExprTree(_q% {'last_completion': last_completion})
     logging.info("Querying %s for history: %s.  "
                  "%.1f minutes of ads", schedd_ad["Name"],
                  history_query,

--- a/src/htcondor_es/history.py
+++ b/src/htcondor_es/history.py
@@ -38,7 +38,7 @@ def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args
     metadata = metadata or {}
     schedd = htcondor.Schedd(schedd_ad)
     _q = "EnteredCurrentStatus >= %(last_completion)d "\
-            "or CRAB_PostJobLastUpdate >= %(last_completion)d" 
+            "|| CRAB_PostJobLastUpdate >= %(last_completion)d" 
     history_query = classad.ExprTree(_q% {'last_completion': last_completion})
     logging.info("Querying %s for history: %s.  "
                  "%.1f minutes of ads", schedd_ad["Name"],


### PR DESCRIPTION
CRAB jobs are currently held in the queue after being completed, and they will be updated after they change to the status complete, we need to query if they were updated by the post job after the last completion. 
This change does not affect the no-CRAB jobs, as we still use the EnteredCurrentStatusDate first (and query for a nonexisting field is not a problem in classad expressions). 

Using the new CRAB_PostJobLastUpdate classad we can identify the latest modification.

See also https://github.com/dmwm/CRABServer/pull/5896# 