### PR TITLE
Prune only running AND always include the  CRAB_PostJobStatus field

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -32,6 +32,7 @@ string_vals = set([ \
   "CRAB_JobArch",
   "CRAB_Id",
   "CRAB_ISB",
+  "CRAB_PostJobStatus",
   "CRAB_Workflow",
   "CRAB_UserRole",
   "CMSGroups",
@@ -450,6 +451,7 @@ running_fields = set([
   "CRAB_AsyncDest",
   "CRAB_DataBlock",
   "CRAB_Id",
+  "CRAB_PostJobStatus",
   "CRAB_Retry",
   "CRAB_TaskCreationDate",
   "CRAB_UserHN",
@@ -648,7 +650,7 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False, aff_mgr=
     except:
         ad["RequestCpus"] = 1.0
     result['RequestCpus'] = ad['RequestCpus']
-
+    
     result["CoreHr"] = ad.get("RequestCpus", 1.0)*int(ad.get("RemoteWallClockTime", 0))/3600.
     result["CommittedCoreHr"] = ad.get("RequestCpus", 1.0)*ad.get("CommittedTime", 0)/3600.
     result["CommittedWallClockHr"] = ad.get("CommittedTime", 0)/3600.
@@ -798,6 +800,14 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False, aff_mgr=
         if _aff is not None: 
             result['AffiliationInstitute'] = _aff['institute']
             result['AffiliationCountry'] = _aff['country']
+            
+    # We will use the CRAB_PostJobStatus as the actual status.
+    # If is an analysis task and is not completed, 
+    # its status is defined by Status, else it will be defined by
+    # CRAB_PostJobStatus.
+    if analysis and result['Status'] != 'Completed':
+        result['CRAB_PostJobStatus'] = result['Status']
+      
     if reduce_data:
         result = drop_fields_for_running_jobs(result)
 

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1158,6 +1158,13 @@ def convert_dates_to_millisecs(record):
 
 
 def drop_fields_for_running_jobs(record):
+    """
+        Check if the job is running or pending
+        and prune it if it is.
+    """
+    if 'Status' in record\
+      and record['Status'] not in ['Running', 'Idle', 'Held']:
+        return record
     skimmed_record = {}
     for field in running_fields:
         try:

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -533,6 +533,14 @@ universe = { \
  12: "Local",
 }
 
+postjob_status_decode = { 
+ 'NOT RUN': 'wnpostproc',
+ 'TRANSFERRING': 'transferring',
+ 'COOLOFF': 'toretry',
+  'FAILED': 'failed',
+  'FINISHED': 'finished'
+ }
+
 _launch_time = int(time.time())
 
 def make_list_from_string_field(ad, key, split_re="\s*,?\s*", default=None):
@@ -805,9 +813,13 @@ def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False, aff_mgr=
     # If is an analysis task and is not completed, 
     # its status is defined by Status, else it will be defined by
     # CRAB_PostJobStatus.
+    # We will use the postjob_status_decode dict to decode 
+    # the status. If there is an unknown value it will set to it. 
     if analysis and result['Status'] != 'Completed':
         result['CRAB_PostJobStatus'] = result['Status']
-      
+    elif 'CRAB_PostJobStatus' in result:
+        _pjst = result['CRAB_PostJobStatus']
+        result[ 'CRAB_PostJobStatus'] = postjob_status_decode.get(_pjst, _pjst)
     if reduce_data:
         result = drop_fields_for_running_jobs(result)
 


### PR DESCRIPTION
In grafana, we will use the CRAB_PostJobStatus to show the actual status of a job. This will contain the current status if the job is not completed, or the current post job status if it is completed. 


0334426 commit modifies the drop_fields_for_running_jobs method to only prune the non-completed yet jobs (Idle, Held, Running)