### PR TITLE
[Affiliation]Do not pickle (multiprocessing), load on import instead.

### DIFF
--- a/cronAffiliation.sh
+++ b/cronAffiliation.sh
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export PYTHONPATH="$DIR/src/:$DIR/../CMSMonitoring/src/python:$PYTHONPATH"
-
+source "$DIR/venv/bin/activate"
 create=$(cat <<EOF
 from htcondor_es.AffiliationManager import AffiliationManager, AffiliationManagerException
 try:

--- a/spider_cms.py
+++ b/spider_cms.py
@@ -22,26 +22,13 @@ import htcondor_es.history
 import htcondor_es.queues
 from htcondor_es.utils import get_schedds, set_up_logging, send_email_alert
 from htcondor_es.utils import collect_metadata, TIMEOUT_MINS
-from htcondor_es.AffiliationManager import AffiliationManager, AffiliationManagerException
-
 
 def main_driver(args):
     """
     Driver method for the spider script.
     """
     starttime = time.time()
-    try:
-        aff_mgr = AffiliationManager(recreate=False)
-    except AffiliationManagerException as e:
-        # If its not possible to create the affiliation manager
-        aff_mgr = None
-        # Log it
-        logging.error("There were an error creating the affiliation manager, %s", e)
-        send_email_alert(args.email_alerts,
-                         'There were an error creating the affiliation manager',
-                         traceback.format_exc(e))
-        # Continue execution without affiliation.
-
+   
     signal.alarm(TIMEOUT_MINS*60 + 60)
 
     # Get all the schedd ads
@@ -57,7 +44,6 @@ def main_driver(args):
                                               starttime=starttime,
                                               pool=pool,
                                               args=args,
-                                              aff_mgr=aff_mgr,
                                               metadata=metadata)
 
     # Now that we have the fresh history, process the queues themselves.
@@ -66,7 +52,6 @@ def main_driver(args):
                                           starttime=starttime,
                                           pool=pool,
                                           args=args,
-                                          aff_mgr=aff_mgr,
                                           metadata=metadata)
 
     pool.close()

--- a/src/htcondor_es/AffiliationManager.py
+++ b/src/htcondor_es/AffiliationManager.py
@@ -38,6 +38,7 @@ class AffiliationManager():
 
         try:
             self.__dir = self.loadOrCreateDirectory(recreate)
+            self.__dn_dir = {person["dn"]:person for person in self.__dir.values()}
         except (IOError, requests.RequestException, requests.HTTPError) as cause:
             raise AffiliationManagerException(cause)
             # python 3 note:
@@ -96,9 +97,7 @@ class AffiliationManager():
         if login:
             return self.__dir.get(login)
         elif dn:
-            for _person in self.__dir.values():
-                if _person['dn'] == dn:
-                    return _person
+            return self.__dn_dir.get(dn)
         return None
 
 

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -10,7 +10,7 @@ import datetime
 import zlib
 import base64
 import htcondor
-from htcondor_es.AffiliationManager import AffiliationManager
+from htcondor_es.AffiliationManager import AffiliationManager, AffiliationManagerException
 
 string_vals = set([ \
   "AutoClusterId",
@@ -533,6 +533,16 @@ universe = { \
 
 _launch_time = int(time.time())
 
+#Initialize aff_mgr
+aff_mgr = None
+try:
+    aff_mgr = AffiliationManager(recreate=False)
+except AffiliationManagerException as e:
+    # If its not possible to create the affiliation manager
+    # Log it
+    logging.error("There were an error creating the affiliation manager, %s", e)
+    # Continue execution without affiliation.
+    
 def make_list_from_string_field(ad, key, split_re="\s*,?\s*", default=None):
     default = default or ['UNKNOWN']
     try:
@@ -569,7 +579,7 @@ _generic_site = re.compile("^[A-Za-z0-9]+_[A-Za-z0-9]+_(.*)_")
 _cms_site = re.compile("CMS[A-Za-z]*_(.*)_")
 _cmssw_version = re.compile("CMSSW_((\d*)_(\d*)_.*)")
 
-def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False, aff_mgr=None):
+def convert_to_json(ad, cms=True, return_dict=False, reduce_data=False):
     if ad.get("TaskType") == "ROOT":
         return None
     result = {}

--- a/src/htcondor_es/history.py
+++ b/src/htcondor_es/history.py
@@ -21,7 +21,7 @@ from htcondor_es.convert_to_json import convert_dates_to_millisecs
 from htcondor_es.convert_to_json import unique_doc_id
 
 
-def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args, metadata=None,aff_mgr=None):
+def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args, metadata=None):
     """
     Given a schedd, process its entire set of history since last checkpoint.
     """
@@ -59,7 +59,7 @@ def process_schedd(starttime, last_completion, checkpoint_queue, schedd_ad, args
         for job_ad in history_iter:
             dict_ad = None
             try:
-                dict_ad = convert_to_json(job_ad, return_dict=True, aff_mgr=aff_mgr)
+                dict_ad = convert_to_json(job_ad, return_dict=True)
             except Exception as e:
                 message = ("Failure when converting document on %s history: %s" %
                            (schedd_ad["Name"], str(e)))
@@ -175,7 +175,7 @@ def update_checkpoint(name, completion_date):
         json.dump(checkpoint, fd)
 
 
-def process_histories(schedd_ads, starttime, pool, args, metadata=None, aff_mgr=None):
+def process_histories(schedd_ads, starttime, pool, args, metadata=None):
     """
     Process history files for each schedd listed in a given
     multiprocessing pool
@@ -209,8 +209,7 @@ def process_histories(schedd_ads, starttime, pool, args, metadata=None, aff_mgr=
                                    checkpoint_queue,
                                    schedd_ad,
                                    args,
-                                   metadata,
-                                   aff_mgr))
+                                   metadata))
         futures.append((name, future))
 
     def _chkp_updater():

--- a/src/htcondor_es/queues.py
+++ b/src/htcondor_es/queues.py
@@ -107,7 +107,7 @@ class ListenAndBunch(multiprocessing.Process):
         self.output_queue.put(self.count_in, timeout=time_remaining(self.starttime))
 
 
-def query_schedd_queue(starttime, schedd_ad, queue, args, aff_mgr=None):
+def query_schedd_queue(starttime, schedd_ad, queue, args):
     my_start = time.time()
     logging.info("Querying %s queue for jobs.", schedd_ad["Name"])
     if time_remaining(starttime) < 10:
@@ -133,7 +133,7 @@ def query_schedd_queue(starttime, schedd_ad, queue, args, aff_mgr=None):
             dict_ad = None
             try:
                 dict_ad = convert_to_json(job_ad, return_dict=True,
-                                          reduce_data=not args.keep_full_queue_data, aff_mgr=aff_mgr)
+                                          reduce_data=not args.keep_full_queue_data)
             except Exception as e:
                 message = ("Failure when converting document on %s queue: %s" %
                            (schedd_ad["Name"], str(e)))
@@ -202,7 +202,7 @@ def query_schedd_queue(starttime, schedd_ad, queue, args, aff_mgr=None):
     return count
 
 
-def process_queues(schedd_ads, starttime, pool, args, metadata=None, aff_mgr=None):
+def process_queues(schedd_ads, starttime, pool, args, metadata=None):
     """
     Process all the jobs in all the schedds given.
     """
@@ -228,7 +228,7 @@ def process_queues(schedd_ads, starttime, pool, args, metadata=None, aff_mgr=Non
 
     for schedd_ad in schedd_ads:
         future = pool.apply_async(query_schedd_queue,
-                                  args=(starttime, schedd_ad, input_queue, args, aff_mgr))
+                                  args=(starttime, schedd_ad, input_queue, args))
         futures.append((schedd_ad['Name'], future))
 
     def _callback_amq(result):

--- a/tests/testDocConversion.py
+++ b/tests/testDocConversion.py
@@ -19,7 +19,6 @@ except ImportError:
 
 from htcondor_es.utils import get_schedds
 from htcondor_es.convert_to_json import convert_to_json
-from htcondor_es.AffiliationManager import AffiliationManager
 
 
 def process_pickle(filename, args):
@@ -27,14 +26,13 @@ def process_pickle(filename, args):
     dumpfile_name = filename.strip('.pck')
     dumpfile = os.path.join(args.dump_target, '%s.json' % dumpfile_name)
     count = 0
-    aff_mgr = AffiliationManager()
     with open(filename, 'r') as pfile, open(dumpfile, 'w') as dfile:
         try:
             job_ads = pickle.load(pfile)
         except Exception, e:
             print e
 
-        dict_ads = [convert_to_json(job_ad, return_dict=True, aff_mgr=aff_mgr) for job_ad in job_ads]
+        dict_ads = [convert_to_json(job_ad, return_dict=True) for job_ad in job_ads]
         dict_ads = filter(None, dict_ads)
         json.dump(dict_ads, dfile, indent=4, sort_keys=True)
         count = len(dict_ads)


### PR DESCRIPTION
This approach is more efficient (it takes less than 8 seconds to process 10000 records in the same process*) 

As future work, we should make a redesign of the current script (is already taking more than 10 minutes, even without Affiliation). Perhaps, together with the migration to Python 3, we could change to a celery-based strategy (having more than one node doing the work).

* The dir is loaded on import, once per process. This removes the burden from `multiprocessing` pickle strategy.  Tested with a minimal setup:
```python
python -m timeit "
from htcondor_es.convert_to_json import convert_to_json
from classad import ClassAd
for x in xrange(0,10000):
    convert_to_json(ClassAd({'CRAB_UserHN':'belforte','JobStatus':4,'NordugridRSL':'-','JobCurrentStartDate':150000000,'QDate':150000000,'CRAB_Id':'%d'%x}))
"
```