### PR TITLE
Take into consideration the JobExitCode.

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -968,12 +968,14 @@ def jobFailed(ad):
 
 def commonExitCode(ad):
     """
-    Consolidate the exit code values of chirped CRAB and WMCore values and
+    Consolidate the exit code values of JobExitCode, 
+    the  chirped CRAB and WMCore values, and
     the original condor exit code.
     """
-    return ad.get('Chirp_CRAB3_Job_ExitCode',
-                  ad.get('Chirp_WMCore_cmsRun_ExitCode',
-                         ad.get('ExitCode', 0)))
+    return ad.get('Chirp_WMCore_cmsRun_ExitCode',
+                  ad.get('JobExitCode',
+                         ad.get('Chirp_CRAB3_Job_ExitCode',
+                                ad.get('ExitCode', 0))))
 
 
 def errorType(ad):


### PR DESCRIPTION
For analysis tasks: 
Use JobExitCode if it exists, else Chirp_CRAB3_Job_ExitCode, else ExitCode.
For WMCore use Chirp_WMCore_cmsRun_ExitCode or 
 ExitCode