### PR TITLE
Filter queues query

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1138,9 +1138,8 @@ def bulk_convert_ad_data(ad, result):
     """
     Given a ClassAd, bulk convert to a python dictionary.
     """
-    for key in ad.keys():
-        if key in ignore:
-            continue
+    _keys = set(ad.keys()) - ignore
+    for key in _keys:
         if key.startswith("HasBeen") and not key in bool_vals:
             continue
         if key == "DESIRED_SITES":
@@ -1212,12 +1211,8 @@ def drop_fields_for_running_jobs(record):
     if 'Status' in record\
       and record['Status'] not in ['Running', 'Idle', 'Held']:
         return record
-    skimmed_record = {}
-    for field in running_fields:
-        try:
-            skimmed_record[field] = record[field]
-        except KeyError: continue
-
+    _fields = running_fields.intersection(set(record.keys()))
+    skimmed_record = {field: record[field] for field in _fields}
     return skimmed_record
 
 

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1163,7 +1163,7 @@ def bulk_convert_ad_data(ad, result):
                     value = None
                 else:
                     logging.warning("Failed to convert key %s with value %s to int" % (key, repr(value)))
-                    value = str(value)
+                    continue
         elif key in string_vals:
             value = str(value)
         elif key in date_vals:


### PR DESCRIPTION
For the completed and removed jobs we are now filtering for the ones that have been updated in the last spider period. 

Assumptions: 
The CRAB_PostJobLastUpdate is updated by crab when the PostJobStatus is updated. 
The TIMEOUT_MINS constant is set to one minute less that the spider period. 

This change will keep sending the expected "snapshot" to MONiT.

Also, some small changes were made to the convert_to_json function to improve the performance (marginal change) and avoid to add a string value to a int field. 