### PR TITLE
There were a not managed exception in the afiliationManager [NOT MERGE]

### DIFF
--- a/src/htcondor_es/AffiliationManager.py
+++ b/src/htcondor_es/AffiliationManager.py
@@ -39,7 +39,7 @@ class AffiliationManager():
         try:
             self.__dir = self.loadOrCreateDirectory(recreate)
             self.__dn_dir = {person["dn"]:person for person in self.__dir.values()}
-        except (IOError, requests.RequestException, requests.HTTPError, json.JSONDecodeError) as cause:
+        except (IOError, requests.RequestException, requests.HTTPError, ValueError) as cause:
             raise AffiliationManagerException(cause)
             # python 3 note:
             # this line should be:
@@ -76,7 +76,7 @@ class AffiliationManager():
                         if 'login' in profile:
                             login = profile['login']
                             break
-                    if login:
+                    if login and 'institute' in person:
                         _tmp_dir[login] = {'institute': person['institute'],
                                            'country': person['institute_country'],
                                            'dn': person['dn']}

--- a/src/htcondor_es/AffiliationManager.py
+++ b/src/htcondor_es/AffiliationManager.py
@@ -39,7 +39,7 @@ class AffiliationManager():
         try:
             self.__dir = self.loadOrCreateDirectory(recreate)
             self.__dn_dir = {person["dn"]:person for person in self.__dir.values()}
-        except (IOError, requests.RequestException, requests.HTTPError) as cause:
+        except (IOError, requests.RequestException, requests.HTTPError, json.JSONDecodeError) as cause:
             raise AffiliationManagerException(cause)
             # python 3 note:
             # this line should be:


### PR DESCRIPTION
The cric service returned an empty (but valid) response, the AffiliationManager created a empty dir file, so when we load the file it failed to decode as JSON. This hotfix manages the exception, but the long term solution is to validate that the response is a valid JSON before save it. 

