### PR TITLE
CMS_Pool: Assign the schedd to the first pool that returned it

### DIFF
--- a/src/htcondor_es/utils.py
+++ b/src/htcondor_es/utils.py
@@ -24,10 +24,13 @@ TIMEOUT_MINS = 11
 
 def get_schedds_from_file(args=None, collectors_file=None):
     schedds = []
+    names = set()
     try:
         pools = json.load(collectors_file)
         for pool in pools:
-            schedds.extend( get_schedds(args, collectors=pools[pool], pool_name=pool))
+            _pool_schedds = get_schedds(args, collectors=pools[pool], pool_name=pool)
+            schedds.extend([s for s in _pool_schedds if s.get("Name") not in names])
+            names.update([s.get("Name") for s in _pool_schedds])
         
     except (IOError, json.JSONDecodeError):
         schedds = get_schedds(args)


### PR DESCRIPTION
Deduplicate the schedds by name. 
This PR is a halfway solution to #142, a definitive solution is still pending. 
*NOTE:* After this PR the order in the collectors.json file will determine the pool of the schedd<sup>+</sup>, so the global pool should be first in the list for the current setup. 

[+]  Actually, it currently affects the assignment but in an unpredictable way (overwriting documents)  