### PR TITLE
Python only creation of the affiliation dir file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN useradd --uid 1414 -ms /bin/bash spider &&\
 chown -R spider /cms-htcondor-es
 USER spider
 ENV PYTHONPATH "${PYTHONPATH}:/cms-htcondor-es/src"
+ENV REQUESTS_CA_BUNDLE "/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"
 WORKDIR /cms-htcondor-es
 ENTRYPOINT ["/usr/bin/python", "/cms-htcondor-es/spider_cms.py"]

--- a/affiliation_cache.py
+++ b/affiliation_cache.py
@@ -1,0 +1,47 @@
+import os
+import argparse
+import traceback
+from htcondor_es.AffiliationManager import (
+    AffiliationManager,
+    AffiliationManagerException,
+)
+
+
+def generate_affiliation_cache(output_file, days=1):
+    """
+        Update the cache file if older than a given number of days.
+    """
+    try:
+
+        AffiliationManager(
+            recreate_older_days=days, dir_file=output_file,
+        )
+    except AffiliationManagerException as e:
+        traceback.print_exc()
+        print("There was an error creating the affiliation manager")
+
+
+if __name__ == "main":
+    output_file = os.getenv(
+        "AFFILIATION_DIR_LOCATION",
+        AffiliationManager._AffiliationManager__DEFAULT_DIR_PATH,
+    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        help="""location of the affiliation cache file
+    By default, it will use the AFFILIATION_DIR_LOCATION env variable if set
+    or the users home as default.""",
+        default=None,
+    )
+    parser.add_argument(
+        "--days",
+        help="How often should the file be updated? (days)",
+        type=int,
+        default=1,
+    )
+    args = parser.parse_args()
+    if args.output:
+        output_file = args.output
+
+    generate_affiliation_cache(output_file, args.days)

--- a/affiliation_cache.py
+++ b/affiliation_cache.py
@@ -1,3 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Christian Ariza <christian.ariza AT gmail [DOT] com>
+# This script uses the AffiliationManager class to create or update
+# the affiliation cache file (an indexed structure of username/login
+# and affiliation institution and country from cric data)
+# How to run:
+#       python affiliation_cache.py
+# This will create a file in the users' home called .affiliation_dir.json,
+# if the file already exists it will overwrite it if and only if it's older
+# than one day. You can specify the location and the recreation period using
+# the optional parameters:
+#       python affiliation_cache.py --output /htcondor_es/aff_dir.json --days 3
+# Thiis script can be setup as a daily cronjob and use the parameters to modify
+# how often the script is updated. 
 import os
 import argparse
 import traceback
@@ -21,7 +36,7 @@ def generate_affiliation_cache(output_file, days=1):
         print("There was an error creating the affiliation manager")
 
 
-if __name__ == "main":
+if __name__ == "__main__":
     output_file = os.getenv(
         "AFFILIATION_DIR_LOCATION",
         AffiliationManager._AffiliationManager__DEFAULT_DIR_PATH,

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -577,7 +577,7 @@ _launch_time = int(time.time())
 aff_mgr = None
 try:
     aff_mgr = AffiliationManager(
-        recreate_older_days=10,
+        recreate=False,
         dir_file=os.getenv(
             "AFFILIATION_DIR_LOCATION",
             AffiliationManager._AffiliationManager__DEFAULT_DIR_PATH,

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import os
 import re
 import json
 import time
@@ -575,7 +576,13 @@ _launch_time = int(time.time())
 # Initialize aff_mgr
 aff_mgr = None
 try:
-    aff_mgr = AffiliationManager(recreate=False)
+    aff_mgr = AffiliationManager(
+        recreate_older_days=10,
+        dir_file=os.getenv(
+            "AFFILIATION_DIR_LOCATION",
+            AffiliationManager._AffiliationManager__DEFAULT_DIR_PATH,
+        ),
+    )
 except AffiliationManagerException as e:
     # If its not possible to create the affiliation manager
     # Log it


### PR DESCRIPTION
In order to replace the cronAfiiliation script and make it configurable, the affiliation_cache will create or update if needed the affiliation cache file in the location specified either by parameter or using the AFFILIATION_DIR_LOCATION environment variable.
The convert_to_json module will use the environment variable to determine the location of the affiliation cache file.
The dockerfile will set the environment variable REQUEST_CA_BUNDLE as required by the request module.

See #152 