### PR TITLE
[CMSMONIT-174] Edit regex of cms campaign type for 'MC Ultralegacy'

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1054,7 +1054,7 @@ def guess_campaign_type(ad, analysis):
     camp = ad.get("WMAgent_RequestName", "UNKNOWN")
     if analysis:
         return "Analysis"
-    elif re.match(r".*(RunIISummer19UL|_UL[0-9]+).*", camp):
+    elif re.match(r".*(RunIISummer(1|2)[0-9]UL|_UL[0-9]+).*", camp):
         return "MC Ultralegacy"
     elif re.match(r".*UltraLegacy.*", camp):
         return "Data Ultralegacy"
@@ -1113,7 +1113,7 @@ def jobFailed(ad):
 
 def commonExitCode(ad):
     """
-    Consolidate the exit code values of JobExitCode, 
+    Consolidate the exit code values of JobExitCode,
     the  chirped CRAB and WMCore values, and
     the original condor exit code.
     JobExitCode and Chirp_CRAB3_Job_ExitCode


### PR DESCRIPTION
- Some campaign types which belongs to MC Ultralegacy is missing from the regex
- i.e. : `RunIISummer29UL17GEN` and `RunIISummer20UL16GEN`
- Regex reference for campaign types: https://its.cern.ch/jira/browse/CMSMONIT-174