### PR TITLE
Build docker image with every push to master with a tag of commit sha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - 'master'
   workflow_dispatch:
     inputs:
       logLevel:
@@ -35,11 +35,17 @@ jobs:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+    - name: Get commit short sha
+      id: vars
+      shell: bash
+      run: |
+        echo ::set-output name=sha_short::$(git rev-parse --short $GITHUB_SHA)
+
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
         context: .
         file: ./Dockerfile
         load: true
-        tags: cmssw/cms-htcondor-es:${{steps.get-ref.outputs.tag}}
-    - run: docker push cmssw/cms-htcondor-es:${{steps.get-ref.outputs.tag}}
+        tags: cmssw/cms-htcondor-es:${{ steps.vars.outputs.sha_short }}
+    - run: docker push cmssw/cms-htcondor-es:${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
@vkuznet I thought that building docker image for each commit(on my side: merge commits) to master branch would be more useful. I don't have access to push tags, so this will improve our deployments IMO. And also, it's more easy to follow docker tags with commit hashes.
i.e. [mrceyhun/cms_htcondor_es:ff9529f](https://hub.docker.com/layers/mrceyhun/cms_htcondor_es/ff9529f/images/sha256-8f1e8e3c3b218e0f10b0a724f37da29fb45b696e5e5af2b76a0b7dab831fc327?context=explore)

What do you think?