### PR TITLE
[CMSMONIT-401] Improve Site name extraction from ClassAd

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -670,7 +670,9 @@ def convert_to_json(
     if cms:
         ad.setdefault(
             "MATCH_EXP_JOB_GLIDEIN_CMSSite",
-            ad.get("MATCH_EXP_JOBGLIDEIN_CMSSite", "Unknown"),
+            ad.get("MATCH_EXP_JOBGLIDEIN_CMSSite",
+                   ad.get("MATCH_GLIDEIN_CMSSite",
+                          ad.get("MachineAttrGLIDEIN_CMSSite0", "Unknown"))),
         )
 
     bulk_convert_ad_data(ad, result)

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -672,7 +672,8 @@ def convert_to_json(
             "MATCH_EXP_JOB_GLIDEIN_CMSSite",
             ad.get("MATCH_EXP_JOBGLIDEIN_CMSSite",
                    ad.get("MATCH_GLIDEIN_CMSSite",
-                          ad.get("MachineAttrGLIDEIN_CMSSite0", "Unknown"))),
+                          ad.get("MachineAttrGLIDEIN_CMSSite0",
+                                 ad.get("MachineAttrCMSProcessingSiteName0", "Unknown")))),
         )
 
     bulk_convert_ad_data(ad, result)


### PR DESCRIPTION
Here is the related PR for improving Site name extraction from ClassAd. Ref: [CMSMONIT-401](https://its.cern.ch/jira/browse/CMSMONIT-401)

Logic is pretty straight forward. It tries to get Site name with an order. Ref for Site name ClassAd attr: [SI_site_attributes_origin](https://docs.google.com/spreadsheets/d/19msyANCX6r7wcGK5igUZX5Ak-EAIuW7NIQMPrRFxNTA/edit#gid=0)
Order is:
1. MATCH_EXP_JOB_GLIDEIN_CMSSite
2. MATCH_EXP_JOBGLIDEIN_CMSSite
3. MATCH_GLIDEIN_CMSSite
4. MachineAttrGLIDEIN_CMSSite0
5. Unknown
