### PR TITLE
Update default exit code whenthere are no classads declaring the exit code

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1154,7 +1154,7 @@ def commonExitCode(ad):
         "JobExitCode",
         ad.get(
             "Chirp_CRAB3_Job_ExitCode",
-            ad.get("Chirp_WMCore_cmsRun_ExitCode", ad.get("ExitCode", 0)),
+            ad.get("Chirp_WMCore_cmsRun_ExitCode", ad.get("ExitCode", 50666)),
         ),
     )
 


### PR DESCRIPTION
This PR changes the default exit code from 0 to 50666: Job removed by condor for unknown reasons.

Related issue #208