### PR TITLE
Make JobFailed() depend on commonExitCode function

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1129,17 +1129,10 @@ def jobFailed(ad):
     Returns 0 when none of the exitcode fields has a non-zero value
     otherwise returns 1
     """
-    ec_fields = [
-        "ExitCode",
-        "Chirp_CRAB3_Job_ExitCode",
-        "Chirp_WMCore_cmsRun_ExitCode",
-        "Chirp_WMCore_cmsRun1_ExitCode",
-        "Chirp_WMCore_cmsRun2_ExitCode",
-    ]
-
-    if sum([ad.get(k, 0) for k in ec_fields]) > 0:
-        return 1
-    return 0
+    if commonExitCode(ad) == 0:
+        return 0
+    else:
+        return 1 
 
 
 def commonExitCode(ad):


### PR DESCRIPTION
Fixes #208

The following change makes JobFailed to be consistent with commonExitCode. It will also rely solely  `Chirp_WMCore_cmsRun_ExitCode` for production (apart from `ExitCode` for non cmsRun jobs, as agreed by the production team
