### PR TITLE
Switch EnteredCurrentStatus to JobFinishedHookDone

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -996,11 +996,11 @@ def recordTime(ad):
         - else fall back to launch time
     """
     if ad["JobStatus"] in [3, 4, 6]:
-        if ad.get("CompletionDate", 0) > 0:
+        if ad.get("CompletionDate", 0):
             return ad["CompletionDate"]
 
-        elif ad.get("EnteredCurrentStatus", 0) > 0:
-            return ad["EnteredCurrentStatus"]
+        elif ad.get("JobFinishedHookDone", 0):
+            return ad["JobFinishedHookDone"]
 
     return _launch_time
 


### PR DESCRIPTION
CMSMONIT-600

Start using `JobFinishedHookDone` instead of `EnterredCurrentStatus`.

 

`RecordTime` indicates when a job finished for jobs that were successful. But without the change, it indicates the time the job was put in the queue (or was running) in the other cases. This is not good both semantically because the same field indicates different things (sometimes the time the job finished, sometimes the time when the jobs was running, sometimes the time when the job was put in the queue), and practically because it does not allow CERN IT to compact the data in HDFS (they keep getting records that goes into old buckets when those records could go into more recent buckets).

FYI @leggerf @brij01 