### PR TITLE
Update logstash.conf

### DIFF
--- a/service-logstash/logstash/etc/conf.d/logstash.conf
+++ b/service-logstash/logstash/etc/conf.d/logstash.conf
@@ -5,7 +5,7 @@ input{
     }
 }
 filter{
-    if [message] =~ "SCHEMA_VALIDATOR: unknown key=.*" {
+    if [message] =~ "SCHEMA_VALIDATOR: unknown key=.*" { # CMSMONIT-604 - stop sending this type of warnings as they create too much traffic in our logs on OpenSearch
         drop { }
     }
 

--- a/service-logstash/logstash/etc/conf.d/logstash.conf
+++ b/service-logstash/logstash/etc/conf.d/logstash.conf
@@ -5,6 +5,10 @@ input{
     }
 }
 filter{
+    if [message] =~ "SCHEMA_VALIDATOR: unknown key=.*" {
+        drop { }
+    }
+
     grok{
         match => {
             "message" => "%{TIMESTAMP_ISO8601:timestamp} : %{WORD:log-source}:%{LOGLEVEL:log-level} - %{GREEDYDATA:message}"


### PR DESCRIPTION
CMSMONIT-604

Stop sending `SCHEMA_VALIDATOR: unknown key` type of warnings as they create too much traffic in our logs.

FYI @leggerf @brij01 