### PR TITLE
Check for UNKNOWN task type

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -682,13 +682,10 @@ def convert_to_json(
         )[-1]
         result["CMS_CampaignType"] = guess_campaign_type(ad, analysis)
         result["Campaign"] = guessCampaign(ad, analysis, result["CMS_CampaignType"])
-        result["TaskType"] = result.get(
-            "CMS_extendedJobType",
-            result.get(
-                "CMS_TaskType",
-                guessTaskType(ad) if not analysis else result["CMS_JobType"],
-            ),
-        )
+        task_type = result.get("CMS_extendedJobType")
+        if task_type == "UNKNOWN" or task_type is None:
+            task_type = result.get("CMS_TaskType", result["CMS_JobType"] if analysis else guessTaskType(ad))
+        result["TaskType"] = task_type
         result["Workflow"] = guessWorkflow(ad, analysis)
     now = time.time()
     if ad.get("JobStatus") == 2 and (ad.get("EnteredCurrentStatus", now + 1) < now):


### PR DESCRIPTION
Should close https://github.com/dmwm/cms-htcondor-es/issues/215.

Update `TaskType` calculation so that when `CMS_extendedJobType` is `UNKNOWN`, `TaskType` would be derived from the other fields (previously it only happened when `CMS_extendedJobType` was `None`).

FYI @leggerf @brij01 