### PR TITLE
Add UCSD pool_name check

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -673,8 +673,8 @@ def convert_to_json(
         result["CondorExitCode"] = ad["ExitCode"]
 
     if cms:
-        result["CMS_JobType"] = str(
-            ad.get("CMS_JobType", "Analysis" if analysis else "Unknown")
+        result["CMS_JobType"] = str(  # temp fix for UCSD jobs since they come with an unknown type
+            ad.get("CMS_JobType", "Analysis" if analysis or pool_name == "UCSD" else "Unknown")
         )
         result["CRAB_AsyncDest"] = str(ad.get("CRAB_AsyncDest", "Unknown"))
         result["WMAgent_TaskType"] = ad.get("WMAgent_SubTaskName", "/UNKNOWN").rsplit(

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -684,7 +684,7 @@ def convert_to_json(
         result["Campaign"] = guessCampaign(ad, analysis, result["CMS_CampaignType"])
         task_type = result.get("CMS_extendedJobType")
         if task_type == "UNKNOWN" or task_type is None:
-            task_type = result.get("CMS_TaskType", result["CMS_JobType"] if analysis else guessTaskType(ad))
+            task_type = result.get("CMS_TaskType", guessTaskType(ad))
         result["TaskType"] = task_type
         result["Workflow"] = guessWorkflow(ad, analysis)
     now = time.time()
@@ -1003,7 +1003,10 @@ def recordTime(ad):
 
 
 def guessTaskType(ad):
-    """Guess the TaskType from the WMAgent subtask name"""
+    """
+    Guess the TaskType from the WMAgent subtask name for Production jobs.
+    Otherwise, use the value from the CMS_JobType or set to UNKNOWN.
+    """
     jobType = ad.get("CMS_JobType", "UNKNOWN")
 
     if jobType == "Processing":

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -684,7 +684,8 @@ def convert_to_json(
         result["Campaign"] = guessCampaign(ad, analysis, result["CMS_CampaignType"])
         task_type = result.get("CMS_extendedJobType")
         if task_type == "UNKNOWN" or task_type is None:
-            task_type = result.get("CMS_TaskType", result["CMS_JobType"] if analysis else guessTaskType(ad))
+            task_type = result.get("CMS_TaskType",  # temp fix for UCSD jobs since they come with an unknown type
+                                   result["CMS_JobType"] if analysis or pool_name == "UCSD" else guessTaskType(ad))
         result["TaskType"] = task_type
         result["Workflow"] = guessWorkflow(ad, analysis)
     now = time.time()

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -684,7 +684,7 @@ def convert_to_json(
         result["Campaign"] = guessCampaign(ad, analysis, result["CMS_CampaignType"])
         task_type = result.get("CMS_extendedJobType")
         if task_type == "UNKNOWN" or task_type is None:
-            task_type = result.get("CMS_TaskType", guessTaskType(ad))
+            task_type = result.get("CMS_TaskType", result["CMS_JobType"] if analysis else guessTaskType(ad))
         result["TaskType"] = task_type
         result["Workflow"] = guessWorkflow(ad, analysis)
     now = time.time()
@@ -1003,10 +1003,7 @@ def recordTime(ad):
 
 
 def guessTaskType(ad):
-    """
-    Guess the TaskType from the WMAgent subtask name for Production jobs.
-    Otherwise, use the value from the CMS_JobType or set to UNKNOWN.
-    """
+    """Guess the TaskType from the WMAgent subtask name"""
     jobType = ad.get("CMS_JobType", "UNKNOWN")
 
     if jobType == "Processing":


### PR DESCRIPTION
[CMSMONIT-572](https://its.cern.ch/jira/browse/CMSMONIT-572)

Adding a pool name check so that the `CMS_JobType` and `TaskType` (gets propagated from the `CMS_JobType` in this case) fields don't remain `Unknown` for the UCSD jobs.

FYI @leggerf @brij01 @belforte 