### PR TITLE
Adding task field and cleaning up after the el9 switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM cern/cc7-base:20230201-1.x86_64 as cern
+FROM cern/alma9-base:20241101-1.x86_64 as cern
 
 # Do not use python:alpine because of long build time and some bugs
-# Prodcution spider uses 3.6
-FROM python:3.6-slim
+# Production spider uses 3.9
+FROM python:3.9-slim
 
 ENV HOME "/home/cmsjobmon"
 ENV PATH "${PATH}:/usr/bin/"
@@ -37,12 +37,9 @@ RUN mkdir $HOME/.globus && \
 
 # openssl is required for python requirements module. git procps unzip libaio1 wget are exist to be able to debug k8s pod
 RUN apt-get update && apt-get install -y bash apt-utils git curl procps unzip libaio1 wget openssl nano jq vim cron && \
-    curl -k -O -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s $kubectl_stable_version)/bin/linux/amd64/kubectl && \
-    mv kubectl /usr/bin && \
-    chmod +x /usr/bin/kubectl && \
     chown -R cmsjobmon $HOME && \
-    python3 -m venv $HOME/cms-htcondor-es/venv3_6 && \
-    $HOME/cms-htcondor-es/venv3_6/bin/pip install --no-cache-dir -r $HOME/cms-htcondor-es/requirements.txt
+    python3 -m venv $HOME/cms-htcondor-es/venv3_9 && \
+    $HOME/cms-htcondor-es/venv3_9/bin/pip install --no-cache-dir -r $HOME/cms-htcondor-es/requirements.txt
 
 USER cmsjobmon
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # be consistent with: https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocms/-/blob/master/data/fqdns/vocms0240.cern.ch.yaml#L7
 # check breaking changes before any update and ask to HTCondor-users <htcondor-users> if you see any problem
-htcondor==23.0.3
+htcondor==23.3.0
 
 # will be removed after full migration to OpenSearch
 elasticsearch~=7.6.0
@@ -9,7 +9,7 @@ elasticsearch~=7.6.0
 # installs also stomp.py==7.0.0
 CMSMonitoring==0.6.12
 
-# last version for Py v3.6
+# last version for Py v3.9
 requests~=2.31
 
 # after any OpenSearch upgrade, it may change

--- a/scripts/test_spider_cms_history.sh
+++ b/scripts/test_spider_cms_history.sh
@@ -27,7 +27,7 @@ _UPLOAD_POOL_SIZE=1
 # ----- : =========== : -----
 
 cd $SPIDER_WORKDIR || exit
-source "$SPIDER_WORKDIR/venv3_6/bin/activate"
+source "$SPIDER_WORKDIR/venv3_9/bin/activate"
 
 # Clean test run, remove affiliation and checkpoint files before test run.
 #rm -f "$SPIDER_WORKDIR"/.affiliation_dir.json

--- a/scripts/test_spider_cms_queues.sh
+++ b/scripts/test_spider_cms_queues.sh
@@ -20,7 +20,7 @@ _UPLOAD_POOL_SIZE=1
 # ----- : =========== : -----
 
 cd $SPIDER_WORKDIR || exit
-source "$SPIDER_WORKDIR/venv3_6/bin/activate"
+source "$SPIDER_WORKDIR/venv3_9/bin/activate"
 
 # Clean test run, remove affiliation and checkpoint files before test run.
 #rm -f $SPIDER_WORKDIR/.affiliation_dir.json

--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -673,6 +673,7 @@ def convert_to_json(
         result["CondorExitCode"] = ad["ExitCode"]
 
     if cms:
+        result["task"] = ad.get("WMAgent_SubTaskName")  # add "task" field to unify with WMArchive
         result["CMS_JobType"] = str(  # temp fix for UCSD jobs since they come with an unknown type
             ad.get("CMS_JobType", "Analysis" if analysis or pool_name == "UCSD" else "Unknown")
         )


### PR DESCRIPTION
- Duplicating `WMAgent_SubTaskName` to `task` field so that it would be easier to filter the workflows on the same field as in WMArchive data
- Adjusting some packages in the testing files after the el9 switch

FYI @leggerf 