### PR TITLE
Add MachineAttrCMSSF_ResourceType0 to running jobs

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -499,6 +499,7 @@ running_fields = {
     "JobLastStartDate",
     "JobUniverse",
     "KEvents",
+    "MachineAttrCMSSF_ResourceType0",
     "MachineAttrCMSSubSiteName0",
     "MachineAttrGLIDEIN_OVERLOAD_ENABLED0",
     "MaxWallTimeMins",


### PR DESCRIPTION
`MachineAttrCMSSF_ResourceType0`  will start to be saved for the running jobs as requested in `CMSMONIT-625`

FYI @leggerf 