### PR TITLE
Update guess_campaign_type

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1094,7 +1094,7 @@ def guess_campaign_type(ad, analysis):
         return "Data Ultralegacy"
     elif re.match(r".*Phase2.*", camp):
         return "Phase2 requests"
-    elif re.match(r".*Run3.*", camp):
+    elif re.match(r".*(Run3|RunIII).*", camp):
         return "Run3 requests"
     elif "RVCMSSW" in camp:
         return "RelVal"


### PR DESCRIPTION
This should fix the problem of incorrectly showing Run2 requests for the `CMS_CampaignType` when it actually should be Run3

FYI @leggerf 