### PR TITLE
Update campaign guessing, to support UL FastSim

### DIFF
--- a/src/htcondor_es/convert_to_json.py
+++ b/src/htcondor_es/convert_to_json.py
@@ -1088,7 +1088,7 @@ def guess_campaign_type(ad, analysis):
     camp = ad.get("WMAgent_RequestName", "UNKNOWN")
     if analysis:
         return "Analysis"
-    elif re.match(r".*(RunIISummer([12])[0-9]UL|_UL[0-9]+).*", camp):
+    elif re.match(r".*(RunII(Summer|Spring)([12])[0-9]UL|_UL[0-9]+).*", camp):
         return "MC Ultralegacy"
     elif re.match(r".*UltraLegacy.*", camp):
         return "Data Ultralegacy"


### PR DESCRIPTION
Run 2 FastSim UL uses `RunIISpring21UL17XXX`, instead of `RunIISummerXXULXXX`. This PR is to include Spring in campaign guessing. Currently, when we look on monitoring, it shows that we are running "classic" Run 2 campaign, not UL. This PR should fix it.

<img width="1000" height="563" alt="Prod-20250719" src="https://github.com/user-attachments/assets/f2a90b87-8bf2-4870-a7ff-5876acf0058e" />
